### PR TITLE
Add network detection and error for iOS and Android

### DIFF
--- a/ProjectList.js
+++ b/ProjectList.js
@@ -2,35 +2,65 @@ import React from 'react'
 import {
   Dimensions,
   ListView,
+  NetInfo,
   StyleSheet,
   Text,
   View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
-import Orientation from 'react-native-orientation'
 import apiClient from 'panoptes-client/lib/api-client'
 import Project from './Project'
 import {MOBILE_PROJECTS} from './constants/mobile_projects'
 
-var {height, width} = Dimensions.get('window');
+var {height, width} = Dimensions.get('window')
 
-var ProjectList = React.createClass({
-  getInitialState: function() {
-    return {
+class ProjectList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       dataSource: new ListView.DataSource({
         rowHasChanged: (row1, row2) => row1 !== row2,
-      })
-    };
-  },
+      }),
+      isConnected: null
+    }
+  }
 
   componentDidMount() {
-    this.getProjects()
-    Orientation.lockToPortrait
-  },
+    NetInfo.isConnected.addEventListener(
+        'change',
+        this._handleConnectivityChange
+    );
+
+    //this is always being set to false (even when connected) in iOS
+    //so, getProjects() will be called in handleConnectionChange
+    //Open issue: https://github.com/facebook/react-native/issues/8469
+    NetInfo.isConnected.fetch().done(
+      (isConnected) => {
+        this.setState({isConnected})
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    NetInfo.isConnected.removeEventListener(
+        'change',
+        this._handleConnectivityChange
+    );
+  }
+
+  _handleConnectivityChange = (isConnected) => {
+    this.setState({
+      isConnected,
+    })
+
+    if ((isConnected === true) && (this.state.dataSource.getRowCount() === 0)){
+      this.getProjects()
+    }
+  }
 
   getDataSource(projects: Array<any>): ListView.DataSource {
     return this.state.dataSource.cloneWithRows(projects);
-  },
+  }
 
   getProjects(){
     apiClient.type('projects').get({id: MOBILE_PROJECTS, cards: true, sort: 'display_name'})
@@ -42,15 +72,26 @@ var ProjectList = React.createClass({
       .catch((error) => {
         console.error(error);
       })
-  },
+  }
 
   renderRow(project) {
     return (
       <Project project={project}/>
     );
-  },
+  }
 
   render() {
+    const projectList =
+      <ListView
+        dataSource={this.state.dataSource}
+        renderRow={this.renderRow}
+      />
+
+    const noConnection =
+      <Text style={styles.message}>
+        You must have an internet connection to use Zooniverse Mobile
+      </Text>
+
     return (
       <View style={styles.container}>
         <View style={styles.titleContainer}>
@@ -63,14 +104,11 @@ var ProjectList = React.createClass({
             Mobile-friendly Projects
           </Text>
         </View>
-        <ListView
-          dataSource={this.state.dataSource}
-          renderRow={this.renderRow}
-        />
+        { this.state.isConnected ? projectList : noConnection }
       </View>
     );
   }
-});
+}
 
 const styles = EStyleSheet.create({
   container: {
@@ -97,7 +135,14 @@ const styles = EStyleSheet.create({
     color: '$textColor',
     fontSize: 24,
     padding: 15,
+  },
+  message: {
+    color: '$textColor',
+    fontSize: 16,
+    fontStyle: 'italic',
+    lineHeight: 24,
+    padding: 15,
   }
 });
 
-module.exports = ProjectList
+export default ProjectList

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-sdk
         android:minSdkVersion="16"


### PR DESCRIPTION
Add network detection and an error in case a network connection loss is detected.
Probably the easiest way to test this is in the iOS simulator is by turning off your computer's wi-fi, in android you have to go into settings and turn cellular off.
Also converts ProjectList from class to react component

Closes #11