### PR TITLE
Add configs for android build (generating the apk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ main.jsbundle
 .idea
 .gradle
 local.properties
+zooniverse-key.keystore
 
 # node.js
 #

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,6 +81,7 @@ def enableSeparateBuildPerCPUArchitecture = false
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
+def pass = getPassword("android@zooniverse.org","android_keystore")
 
 android {
     compileSdkVersion 23
@@ -96,6 +97,14 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    signingConfigs {
+        release {
+            storeFile file(MYAPP_RELEASE_STORE_FILE)
+            storePassword pass
+            keyAlias MYAPP_RELEASE_KEY_ALIAS
+            keyPassword pass
+        }
+    }
     splits {
         abi {
             reset()
@@ -108,6 +117,7 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            signingConfig signingConfigs.release
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+def getPassword(String currentUser, String keyChain) {
+   def stdout = new ByteArrayOutputStream()
+   def stderr = new ByteArrayOutputStream()
+   exec {
+       commandLine 'security', '-q', 'find-generic-password', '-a', currentUser, '-s', keyChain, '-w'
+       standardOutput = stdout
+       errorOutput = stderr
+       ignoreExitValue true
+   }
+   //noinspection GroovyAssignabilityCheck
+      stdout.toString().trim()
+}
+
 buildscript {
     repositories {
         jcenter()


### PR DESCRIPTION
Adds config updates to enable generating the android apk.
https://facebook.github.io/react-native/docs/signed-apk-android.html
(keystore isn't checked in, anyone else wishing to run this will need they keystore, I can supply)