### PR TITLE
Google analytics - change screen tracking to Event (on Android)

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -10,7 +10,7 @@ import theme from './theme'
 import {GLOBALS} from './constants/globals'
 
 GoogleAnalytics.setTrackerId(GLOBALS.GOOGLE_ANALYTICS_TRACKING)
-GoogleAnalytics.trackScreenView('Home')
+GoogleAnalytics.trackEvent('view', 'Home')
 
 class ZooniverseMobile extends Component {
   render() {


### PR DESCRIPTION
Make sure the tracking for Android mimics the tracking for iOS