### PR TITLE
Add and style side drawer

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -18,6 +18,7 @@ class ZooniverseMobile extends Component {
           translucent={false}
         />
         <App />
+        <View style={styles.statusBar} />
       </View>
     );
   }
@@ -27,6 +28,14 @@ const styles = EStyleSheet.create({
   container: {
     flex: 1,
   },
+  statusBar:{
+    position: 'absolute',
+    backgroundColor: '$headerColor',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 22
+  }
 });
 
 EStyleSheet.build(theme);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "15.3.1",
     "react-native": "0.32.0",
     "react-native-browser-builtins": "^2.0.3",
+    "react-native-drawer": "^2.3.0",
     "react-native-extended-stylesheet": "^0.3.0",
     "react-native-google-analytics-bridge": "^3.1.0",
     "react-native-loading-spinner-overlay": "^0.3.0",

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -30,6 +30,10 @@ class NavBar extends Component {
     Actions.pop()
   }
 
+  handleSideDrawer(){
+    Actions.refresh({key: 'drawer', open: true })
+  }
+
   render() {
     const containerHeight = (this.props.showAvatar ? height + 70 : height )
     const logo = <Image source={require('../../images/logo.png')} style={styles.logo} />
@@ -53,11 +57,13 @@ class NavBar extends Component {
         <Icon name="angle-left" style={styles.icon} />
       </TouchableOpacity>
 
-    //TODO: Implement side drawer
     const drawer =
-      <Text style={styles.rightIcon}>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        onPress={this.handleSideDrawer.bind(this)}
+        style={styles.rightIcon}>
         <Icon name="bars" style={[styles.icon, styles.iconBar]} />
-      </Text>
+      </TouchableOpacity>
 
     return (
       <View style={[styles.navBarContainer, {height: containerHeight}]}>
@@ -95,14 +101,14 @@ const styles = EStyleSheet.create({
   },
   rightIcon: {
     position: 'absolute',
-    right: 12,
-    top: topPadding + 8
+    right: 0,
+    top: topPadding + 8,
   },
   icon: {
     backgroundColor: '$transparent',
     color: '$textColor',
     fontSize: 30,
-    width: 60
+    width: 40
   },
   iconBar: {
     fontSize: 24

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -9,7 +9,6 @@ import {
 import EStyleSheet from 'react-native-extended-stylesheet'
 import StyledText from './StyledText'
 import { addIndex, filter, map, propEq } from 'ramda'
-import { signOut } from '../actions/index'
 import { connect } from 'react-redux'
 import {GLOBALS} from '../constants/globals'
 import GoogleAnalytics from 'react-native-google-analytics-bridge'
@@ -25,21 +24,9 @@ const mapStateToProps = (state) => ({
   isFetching: state.isFetching
 })
 
-const mapDispatchToProps = (dispatch) => ({
-  signOut() {
-    dispatch(signOut())
-  },
-})
-
 class ProjectDisciplines extends React.Component {
   constructor(props) {
-    super(props)
-    this.handleSignOut = this.handleSignOut.bind(this)
-  }
-
-  //this will be moved to the side drawer once implemented
-  handleSignOut() {
-    this.props.signOut()
+    super(props);
   }
 
   render() {
@@ -71,9 +58,6 @@ class ProjectDisciplines extends React.Component {
       <View style={styles.container}>
         <View style={styles.subNavContainer}>
           <Text style={styles.userName}>{ this.props.user.display_name }</Text>
-          <TouchableOpacity onPress={this.handleSignOut} style={styles.signOut}>
-            <Text style={styles.signOutText}>LOG OUT</Text>
-          </TouchableOpacity>
         </View>
         <View style={styles.innerContainer}>
           { this.props.isConnected ? DisciplineList : noConnection }
@@ -94,7 +78,7 @@ const styles = EStyleSheet.create({
     paddingTop: 140,
     alignItems: 'center',
     justifyContent: 'flex-start',
-    height: 190
+    height: 180
   },
   userName: {
     color: '$darkTextColor',
@@ -124,4 +108,4 @@ ProjectDisciplines.propTypes = {
   signOut: React.PropTypes.func
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectDisciplines)
+export default connect(mapStateToProps)(ProjectDisciplines)

--- a/src/components/SideDrawer.js
+++ b/src/components/SideDrawer.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import Drawer from 'react-native-drawer'
+import SideDrawerContent from './SideDrawerContent'
+import {Actions, DefaultRenderer} from 'react-native-router-flux'
+
+class SideDrawer extends Component {
+  render () {
+    const state = this.props.navigationState
+    const children = state.children
+
+    return (
+      <Drawer
+        ref="drawer"
+        open={state.open}
+        onOpen={()=>Actions.refresh({key:state.key, open: true})}
+        onClose={()=>Actions.refresh({key:state.key, open: false})}
+        type="overlay"
+        side="right"
+        content={<SideDrawerContent />}
+        tapToClose={true}
+        openDrawerOffset={0.3}
+        panCloseMask={0.2}
+        closedDrawerOffset={-3}
+        styles={drawerStyles}
+        tweenHandler={(ratio) => ({
+          main: { opacity:(2-ratio)/2 }
+        })}
+        >
+        <DefaultRenderer navigationState={children[0]} onNavigate={this.props.onNavigate} />
+      </Drawer>
+    )
+  }
+}
+
+const drawerStyles = {
+  drawer: {
+    backgroundColor: 'white',
+    shadowColor: 'black',
+    shadowOpacity: 0.8,
+    shadowRadius: 3,
+    elevation: 3,
+  }
+}
+
+SideDrawer.propTypes = {
+  onNavigate: React.PropTypes.func,
+  navigationState: React.PropTypes.object,
+}
+
+export default SideDrawer

--- a/src/components/SideDrawerContent.js
+++ b/src/components/SideDrawerContent.js
@@ -1,0 +1,158 @@
+import React, { Component } from 'react'
+import {
+  Alert,
+  Linking,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import {Actions} from 'react-native-router-flux'
+import Icon from 'react-native-vector-icons/FontAwesome'
+import StyledText from './StyledText'
+import { signOut } from '../actions/index'
+import { connect } from 'react-redux'
+import GoogleAnalytics from 'react-native-google-analytics-bridge'
+
+const mapStateToProps = (state) => ({
+  user: state.user,
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  signOut() {
+    dispatch(signOut())
+  },
+})
+
+class SideDrawerContent extends Component {
+  constructor(props) {
+    super(props)
+    this.close = this.close.bind(this)
+    this.goHome = this.goHome.bind(this)
+    this.signOut = this.signOut.bind(this)
+  }
+
+  close() {
+    //Timeout used due to open issue:  https://github.com/aksonov/react-native-router-flux/issues/1125
+    setTimeout(() => Actions.refresh({key: 'drawer', open: false }), 0)
+  }
+
+  goHome(){
+    this.close()
+    Actions.ZooniverseApp()
+  }
+
+  signOut(){
+    this.close()
+    this.props.signOut()
+  }
+
+  openSocialMediaLink(link) {
+    GoogleAnalytics.trackEvent('view', link)
+
+    Linking.canOpenURL(link).then(supported => {
+      if (supported) {
+        Linking.openURL(link);
+      } else {
+        Alert.alert(
+          'Error', 'Sorry, but it looks like you are unable to open the link ' + link + ' in your default browser.',
+        )
+      }
+    });
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity
+          activeOpacity={0.5}
+          onPress={this.close}
+          style={styles.closeIcon}>
+          <Icon name="times" style={styles.icon} />
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={this.goHome} style={styles.linkContainer}>
+          <StyledText
+            textStyle={'largeLink'}
+            text={'Home'} />
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={this.goHome} style={styles.linkContainer}>
+          <StyledText
+            textStyle={'largeLink'}
+            text={'About'} />
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={this.goHome} style={styles.linkContainer}>
+          <StyledText
+            textStyle={'largeLink'}
+            text={'Publications'} />
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={this.signOut} style={styles.linkContainer}>
+          <StyledText
+            textStyle={'largeLink'}
+            text={'Sign Out'} />
+        </TouchableOpacity>
+
+
+        <View style={styles.socialMediaContainer}>
+          <TouchableOpacity onPress={() => this.openSocialMediaLink('https://twitter.com/the_zooniverse')}>
+            <Icon name="twitter" style={styles.socialMediaIcon} />
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={() => this.openSocialMediaLink('http://www.facebook.com/therealzooniverse')}>
+            <Icon name="facebook-official" style={styles.socialMediaIcon} />
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={() => this.openSocialMediaLink('http://dailyzooniverse.tumblr.com/')}>
+            <Icon name="tumblr" style={styles.socialMediaIcon} />
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={() => this.openSocialMediaLink('https://plus.google.com/+ZooniverseOrgReal/')}>
+            <Icon name="google-plus" style={styles.socialMediaIcon} />
+          </TouchableOpacity>
+        </View>
+
+      </View>
+    )
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 25,
+    paddingTop: 80
+  },
+  closeIcon: {
+    position: 'absolute',
+    right: 5,
+    top: 24
+  },
+  icon: {
+    color: '$headerColor',
+    fontSize: 24,
+    padding: 10
+  },
+  linkContainer: {
+    height: 40
+  },
+  socialMediaContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    paddingTop: 30
+  },
+  socialMediaIcon: {
+    color: '$darkTextColor',
+    fontSize: 18,
+    width: 50,
+    height: 30,
+  }
+});
+
+SideDrawerContent.propTypes = {
+  user: React.PropTypes.object,
+  signOut: React.PropTypes.func
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SideDrawerContent)

--- a/src/components/StyledText.js
+++ b/src/components/StyledText.js
@@ -31,6 +31,10 @@ const styles = EStyleSheet.create({
   },
   link: {
     color: '$headerColor'
+  },
+  largeLink: {
+    color: '$darkTextColor',
+    fontSize: 20,
   }
 });
 

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -11,6 +11,7 @@ import ZooniverseApp from './zooniverseApp'
 import ProjectList from '../components/ProjectList'
 import ProjectDisciplines from '../components/ProjectDisciplines'
 import SignIn from '../components/SignIn'
+import SideDrawer from '../components/SideDrawer'
 
 const store = compose(applyMiddleware(thunkMiddleware))(createStore)(reducer)
 
@@ -28,12 +29,14 @@ export default class App extends Component {
     store.dispatch(setUserFromStore())
     return (
       <Provider store={store}>
-        <Router>
-          <Scene key="root">
-            <Scene key="ZooniverseApp" component={ZooniverseApp} initial />
-            <Scene key="ProjectDisciplines" component={ProjectDisciplines} />
-            <Scene key="ProjectList" component={ProjectList} />
-            <Scene key="SignIn" hideNavBar={true} component={SignIn} type="reset" />
+        <Router ref="router">
+          <Scene ref="drawer" key="drawer" component={SideDrawer} open={false}>
+            <Scene key="main" tabs={false} >
+              <Scene key="SignIn" hideNavBar={true} component={SignIn} type="reset" />
+              <Scene key="ZooniverseApp" component={ZooniverseApp} initial />
+              <Scene key="ProjectDisciplines" component={ProjectDisciplines} />
+              <Scene key="ProjectList" component={ProjectList} />
+            </Scene>
           </Scene>
         </Router>
       </Provider>


### PR DESCRIPTION
Closes #35 

Adds a new side drawer component:
  *  Added to router
  *  Added placeholder links (About and Publications just go Home for now)
  *  Added links to social media
  *  Also moved the Signout link currently on the home page to the side drawer
  *  Adds status bar opaque teal for iOS to display on top