### PR TITLE
Fix android permissions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,11 +115,16 @@ android {
         }
     }
     buildTypes {
+        debug {
+            manifestPlaceholders = [excludeSystemAlertWindowPermission: "false"]
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
+            manifestPlaceholders = [excludeSystemAlertWindowPermission: "true"]
         }
+
     }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.zooniversemobile"
     android:versionCode="1"
-    android:versionName="1.0">
+    android:versionName="1.0"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:remove="${excludeSystemAlertWindowPermission}"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" tools:node="remove"/>
 
     <uses-sdk
         android:minSdkVersion="16"


### PR DESCRIPTION
Removes unnecessary Android permissions being automatically added by RN.

Changes SYSTEM_ALERT_WINDOW to only display in debug mode
Removes BLUETOOTH, READ_EXTERNAL_STORAGE and READ_PHONE_STATE 

You can check the permission changes either through the device or emulators settings, or by following the instructions here (requires an apk and adb in your path):  http://stackoverflow.com/questions/21091022/listing-permissions-of-android-application-via-adb
Fixes #47 