### PR TITLE
Rename variable for readability

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,13 +116,13 @@ android {
     }
     buildTypes {
         debug {
-            manifestPlaceholders = [excludeSystemAlertWindowPermission: "false"]
+            manifestPlaceholders = [shouldRemoveSystemAlertWindowPermission: "false"]
         }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
-            manifestPlaceholders = [excludeSystemAlertWindowPermission: "true"]
+            manifestPlaceholders = [shouldRemoveSystemAlertWindowPermission: "true"]
         }
 
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:remove="${excludeSystemAlertWindowPermission}"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:remove="${shouldRemoveSystemAlertWindowPermission}"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>


### PR DESCRIPTION
Based on feedback for PR #57 - I just renamed the variable from excludeSystemAlertWindowPermission to shouldRemoveSystemAlertWindowPermission (it needs to have that true/false values preserved, I could negate it but that also makes it less readable imo).
I think this improves the understandability of what it's doing.  (if you have any other ideas I'm good with that too - thanks!)