### PR TITLE
Make tappable area larger for touch elements

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -95,19 +95,20 @@ const styles = EStyleSheet.create({
   },
   leftIcon: {
     position: 'absolute',
-    left: 13,
-    top: topPadding + 4
+    left: 5,
+    top: topPadding - 2
   },
   rightIcon: {
     position: 'absolute',
-    right: 0,
-    top: topPadding + 8,
+    right: 10,
+    top: topPadding,
   },
   icon: {
     backgroundColor: '$transparent',
     color: '$textColor',
     fontSize: 30,
-    width: 40
+    width: 40,
+    padding: 10
   },
   iconBar: {
     fontSize: 24

--- a/src/components/SideDrawerContent.js
+++ b/src/components/SideDrawerContent.js
@@ -152,7 +152,6 @@ class SideDrawerContent extends Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    padding: 25,
     paddingTop: 80
   },
   closeIcon: {
@@ -166,18 +165,20 @@ const styles = EStyleSheet.create({
     padding: 10
   },
   linkContainer: {
-    height: 40
+    paddingLeft: 25,
+    paddingTop: 8,
+    paddingBottom: 8
   },
   socialMediaContainer: {
     flexDirection: 'row',
-    justifyContent: 'center',
-    paddingTop: 30
+    justifyContent: 'flex-start',
+    paddingTop: 15,
+    paddingLeft: 15
   },
   socialMediaIcon: {
     color: '$darkTextColor',
     fontSize: 18,
-    width: 50,
-    height: 30,
+    padding: 12,
   }
 });
 

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -104,7 +104,7 @@ class SignIn extends React.Component {
             handleOnChangeText={(password) => this.setState({password})} />
           { this.props.errorMessage ? errorMessage : null }
           <TouchableOpacity
-            onPress={this.handleResetPassword}>
+            onPress={this.handleResetPassword} style={styles.forgotPasswordContainer}>
             <StyledText
               textStyle={'link'}
               text={ 'Forget your password?' } />
@@ -163,6 +163,10 @@ const styles = EStyleSheet.create({
   },
   centerText: {
     margin: 20
+  },
+  forgotPasswordContainer: {
+    paddingTop: 10,
+    paddingBottom: 10
   }
 });
 


### PR DESCRIPTION
The following touch elements have a rather small tappable area so to make it easier to tap I've increased the padding on the following items:
  *  Side menu open (in nav bar)
  *  Back arrow (in nav bar)
  *  Social icons (in side menu)
  *  Links (in side menu)
  *  Forgot password link (on sign in)