### PR TITLE
Refactor project list display a bit

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,8 +13,10 @@ import auth from 'panoptes-client/lib/auth'
 import apiClient from 'panoptes-client/lib/api-client'
 import store from 'react-native-simple-store'
 import { PUBLICATIONS } from '../constants/publications'
+import { MOBILE_PROJECTS } from '../constants/mobile_projects'
+import { GLOBALS } from '../constants/globals'
 import { NetInfo } from 'react-native'
-import { addIndex, forEach, head, keys, map } from 'ramda'
+import { addIndex, filter, forEach, head, keys, map, propEq } from 'ramda'
 import { Actions, ActionConst } from 'react-native-router-flux'
 
 export function setState(stateKey, value) {
@@ -117,13 +119,21 @@ export function signOut() {
   }
 }
 
-export function fetchProjects(parms) {
+export function fetchProjects() {
   return dispatch => {
     dispatch(setError(''))
-    dispatch(setIsFetching(false))
+    var callFetchProjects = tag => dispatch(fetchProjectsByTag(tag.value))
+    forEach(callFetchProjects, filter(propEq('display', true), GLOBALS.DISCIPLINES))
+  }
+}
+
+
+export function fetchProjectsByTag(tag) {
+  const parms = {id: MOBILE_PROJECTS, cards: true, tags: tag, sort: 'display_name'}
+  return dispatch => {
     apiClient.type('projects').get(parms)
       .then((projects) => {
-        dispatch(setProjectList(projects))
+        dispatch(setState(`projectList.${tag}`,projects))
       })
       .catch((error) => {
         dispatch(setError('The following error occurred.  Please close down Zooniverse and try again.  If it persists please notify us.  \n\n' + error,))

--- a/src/components/Discipline.js
+++ b/src/components/Discipline.js
@@ -18,7 +18,8 @@ class Discipline extends Component {
 
   handleClick() {
     GoogleAnalytics.trackEvent('view', this.props.tag)
-    Actions.ProjectList({tag: this.props.tag})
+    this.props.setSelectedProjectTag()
+    Actions.ProjectList()
   }
 
   render() {
@@ -29,7 +30,7 @@ class Discipline extends Component {
           <View style={styles.zooIconContainer}>
             <ZooIcon iconName={this.props.icon} />
           </View>
-          <Text style={styles.title} numberOfLines={1} ellipsizeMode={"tail"}>{this.props.title}</Text>
+          <Text style={styles.title} numberOfLines={1} ellipsizeMode={'tail'}>{this.props.title}</Text>
           <Icon name="angle-right" style={styles.icon} />
         </View>
       </TouchableOpacity>
@@ -74,7 +75,8 @@ Discipline.propTypes = {
   icon: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
   tag: React.PropTypes.string.isRequired,
-  color: React.PropTypes.string.isRequired
+  color: React.PropTypes.string.isRequired,
+  setSelectedProjectTag: React.PropTypes.func.isRequired
 }
 
 export default Discipline

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -13,6 +13,7 @@ import {GLOBALS} from '../constants/globals'
 import GoogleAnalytics from 'react-native-google-analytics-bridge'
 import Discipline from './Discipline'
 import OverlaySpinner from './OverlaySpinner'
+import { setState } from '../actions/index'
 
 GoogleAnalytics.setTrackerId(GLOBALS.GOOGLE_ANALYTICS_TRACKING)
 GoogleAnalytics.trackEvent('view', 'Home')
@@ -22,6 +23,12 @@ const mapStateToProps = (state) => ({
   isGuestUser: state.user.isGuestUser,
   isConnected: state.isConnected,
   isFetching: state.isFetching
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  setSelectedProjectTag(tag) {
+    dispatch(setState('selectedProjectTag', tag))
+  },
 })
 
 class ProjectDisciplines extends React.Component {
@@ -37,7 +44,8 @@ class ProjectDisciplines extends React.Component {
           title={label}
           tag={value}
           key={idx}
-          color={color} /> )
+          color={color}
+          setSelectedProjectTag={() => {this.props.setSelectedProjectTag(value)}} /> )
     }
 
     const DisciplineList =
@@ -108,7 +116,7 @@ ProjectDisciplines.propTypes = {
   isGuestUser: React.PropTypes.bool,
   isConnected: React.PropTypes.bool,
   isFetching: React.PropTypes.bool,
-  signOut: React.PropTypes.func
+  setSelectedProjectTag: React.PropTypes.func,
 }
 
-export default connect(mapStateToProps)(ProjectDisciplines)
+export default connect(mapStateToProps, mapDispatchToProps)(ProjectDisciplines)

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -5,10 +5,8 @@ import {
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import StyledText from './StyledText'
-import { MOBILE_PROJECTS } from '../constants/mobile_projects'
 import Project from './Project'
 import NavBar from './NavBar'
-import { fetchProjects, setProjectList } from '../actions/index'
 import { connect } from 'react-redux'
 import GoogleAnalytics from 'react-native-google-analytics-bridge'
 
@@ -17,16 +15,7 @@ GoogleAnalytics.trackEvent('view', 'Project')
 const mapStateToProps = (state) => ({
   user: state.user,
   isConnected: state.isConnected,
-  dataSource: dataSource.cloneWithRows(state.projectList)
-})
-
-const mapDispatchToProps = (dispatch) => ({
-  fetchProjects(parms) {
-    dispatch(fetchProjects(parms))
-  },
-  resetProjectList() {
-    dispatch(setProjectList([]))
-  },
+  dataSource: dataSource.cloneWithRows(state.projectList[state.selectedProjectTag])
 })
 
 const dataSource = new ListView.DataSource({
@@ -36,12 +25,6 @@ const dataSource = new ListView.DataSource({
 class ProjectList extends React.Component {
   constructor(props) {
     super(props)
-    const parms = {id: MOBILE_PROJECTS, cards: true, tags: this.props.tag, sort: 'display_name'}
-    this.props.fetchProjects(parms)
-  }
-
-  componentWillUnmount() {
-    this.props.resetProjectList()
   }
 
   renderRow(project) {
@@ -51,7 +34,7 @@ class ProjectList extends React.Component {
   }
 
   static renderNavigationBar() {
-    return <NavBar title={"Projects"} showBack={true} />;
+    return <NavBar title={'Projects'} showBack={true} />;
   }
 
   render() {
@@ -99,8 +82,6 @@ ProjectList.propTypes = {
   user: React.PropTypes.object,
   isConnected: React.PropTypes.bool,
   dataSource: React.PropTypes.object,
-  tag: React.PropTypes.string,
-  fetchProjects: React.PropTypes.func
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectList)
+export default connect(mapStateToProps)(ProjectList)

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import reducer from '../reducers/index'
 import thunkMiddleware from 'redux-thunk'
 import {Scene, Router} from 'react-native-router-flux'
-import { setIsConnected, setUserFromStore } from '../actions/index'
+import { setIsConnected, setUserFromStore, fetchProjects } from '../actions/index'
 
 import ZooniverseApp from './zooniverseApp'
 import ProjectList from '../components/ProjectList'
@@ -25,6 +25,8 @@ export default class App extends Component {
       store.dispatch(setIsConnected(isConnected))
       NetInfo.isConnected.addEventListener('change', dispatchConnected)
     })
+
+    store.dispatch(fetchProjects())
   }
 
   render() {


### PR DESCRIPTION
Fixes #60 
When quickly navigating around, the router is not always doing component unmounts/mounts (https://github.com/aksonov/react-native-router-flux/issues/415) and so the project list isn't properly refreshing
This PR moves more of the logic for filtering project lists into redux, and fetches once on application mount, then just filters the list displayed once a discipline is chosen (rather than an API call each time the component is mounted)