### PR TITLE
Add jest snapshot unit tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+// .babelrc
+{
+  "presets": ["react-native"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
     "browser": true,
     "es6": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "rules": {
     "quotes": [

--- a/README.md
+++ b/README.md
@@ -46,4 +46,8 @@ react-native run-android
 
 ### Testing
 Unit tests utilize Jests' Snapshots, located in src/****/__tests__ directories.  Mocks are located under root /__mocks__ directory.
-To run test suite, use `npm test`.  To update a snapshot (legimately changed) during development, use `npm test -- -u TESTNAME`.  Snapshots should be committed to the repo and any changes to snapshots should be reviewed along with their PRs.
+To run the test suite, use `npm test`.  
+
+About Snapshots:  Facebook's native apps use a system called "snapshot testing":  a snapshot test system that renders UI components, takes a screenshot and subsequently compares a recorded screenshot with changes made by an engineer.  It is meant to make sure components don't change unexpectedly.  The first time a test is run, Jest will create a snapshot file that needs to be committed alongside code changes.  On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the implementation has changed and the snapshot needs to be updated with `npm test -- -u TESTNAME` or it indicates there is a bug that needs to be fixed.
+
+Snapshots should be committed to the repo and any changes to snapshots should be reviewed along with their PRs.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ To run in the emulator from the command line (you'll need device connected or em
 react-native run-android
 *Note* You need to have either a device emulator open already or a physical device plugged into your computer - otherwise you'll need to run through Android Studio
 *Note* If Android studio prompts you to update Gradle Files, you should do it
+
+### Testing
+Unit tests utilize Jests' Snapshots, located in src/****/__tests__ directories.  Mocks are located under root /__mocks__ directory.
+To run test suite, use `npm test`.  To update a snapshot (legimately changed) during development, use `npm test -- -u TESTNAME`.  Snapshots should be committed to the repo and any changes to snapshots should be reviewed along with their PRs.

--- a/__mocks__/react-native-google-analytics-bridge.js
+++ b/__mocks__/react-native-google-analytics-bridge.js
@@ -1,0 +1,6 @@
+export default {
+  trackScreenView() {},
+  trackEvent() {},
+  setUser() {},
+  setTrackerId() {}
+};

--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest",
+    "test:watch": "npm test -- --watch"
+  },
+  "jest": {
+    "preset": "jest-react-native"
   },
   "dependencies": {
     "panoptes-client": "^2.5.2",
     "ramda": "^0.22.1",
-    "react": "^15.3.2",
+    "react": "~15.3.1",
     "react-native": "^0.37.0",
     "react-native-browser-builtins": "^2.0.3",
     "react-native-drawer": "^2.3.0",
@@ -25,11 +30,16 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
+    "babel-jest": "^17.0.2",
+    "babel-preset-react-native": "^1.9.0",
     "eslint": "^3.4.0",
     "eslint-config-standard": "^6.0.0",
-    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-react": "^6.2.0",
     "eslint-plugin-react-native": "^2.0.0",
-    "eslint-plugin-standard": "^2.0.0"
+    "eslint-plugin-standard": "^2.0.0",
+    "jest": "^17.0.2",
+    "jest-react-native": "^17.0.2",
+    "react-test-renderer": "^15.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "panoptes-client": "^2.5.2",
     "ramda": "^0.22.1",
-    "react": "~15.3.1",
-    "react-native": "^0.37.0",
+    "react": "~15.3.2",
+    "react-native": "~0.37.0",
     "react-native-browser-builtins": "^2.0.3",
     "react-native-drawer": "^2.3.0",
     "react-native-extended-stylesheet": "^0.3.0",
@@ -39,7 +39,7 @@
     "eslint-plugin-react-native": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0",
     "jest": "^17.0.2",
-    "jest-react-native": "^17.0.2",
-    "react-test-renderer": "^15.3.2"
+    "jest-react-native": "~17.0.2",
+    "react-test-renderer": "~15.3.2"
   }
 }

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -19,7 +19,7 @@ const mapStateToProps = (state) => ({
   user: state.user,
 })
 
-class NavBar extends Component {
+export class NavBar extends Component {
   constructor(props) {
     super(props)
     this.handleOnBack = this.handleOnBack.bind(this)
@@ -121,6 +121,7 @@ const styles = EStyleSheet.create({
   },
   logo: {
     width: '40%',
+    height: 50,
     resizeMode: 'contain',
     position: 'relative',
     top: 5

--- a/src/components/OverlaySpinner.js
+++ b/src/components/OverlaySpinner.js
@@ -11,7 +11,7 @@ const mapStateToProps = (state) => ({
   isFetching: state.isFetching
 })
 
-class OverlaySpinner extends Component {
+export class OverlaySpinner extends Component {
   render() {
     return (
       <View style={styles.container}>

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 })
 
-class ProjectDisciplines extends React.Component {
+export class ProjectDisciplines extends React.Component {
   constructor(props) {
     super(props);
   }

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -22,7 +22,7 @@ const dataSource = new ListView.DataSource({
   rowHasChanged: (r1, r2) => r1 !== r2,
 })
 
-class ProjectList extends React.Component {
+export class ProjectList extends React.Component {
   constructor(props) {
     super(props)
   }

--- a/src/components/PublicationFilter.js
+++ b/src/components/PublicationFilter.js
@@ -8,24 +8,9 @@ import {
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import StyledText from './StyledText'
-import { setState } from '../actions/index'
-import { connect } from 'react-redux'
 import { addIndex, compose, join, keys, length, lensIndex, map, over, toUpper } from 'ramda'
 import { PUBLICATIONS } from '../constants/publications'
 import Icon from 'react-native-vector-icons/FontAwesome'
-
-const mapStateToProps = (state) => ({
-  user: state.user,
-  isConnected: state.isConnected,
-  disciplines: keys(state.publications),
-  selectedDiscipline: state.selectedDiscipline || null,
-})
-
-const mapDispatchToProps = (dispatch) => ({
-  setSelectedDiscipline(selected) {
-    dispatch(setState('selectedDiscipline', selected))
-  },
-})
 
 class PublicationFilter extends React.Component {
   constructor(props) {
@@ -191,11 +176,9 @@ const styles = EStyleSheet.create({
 });
 
 PublicationFilter.propTypes = {
-  user: React.PropTypes.object,
-  isConnected: React.PropTypes.bool,
   selectedDiscipline: React.PropTypes.string,
   disciplines: React.PropTypes.array,
   setSelectedDiscipline: React.PropTypes.func
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PublicationFilter)
+export default PublicationFilter

--- a/src/components/PublicationList.js
+++ b/src/components/PublicationList.js
@@ -10,7 +10,7 @@ import StyledText from './StyledText'
 import Publication from './Publication'
 import PublicationFilter from './PublicationFilter'
 import NavBar from './NavBar'
-import { fetchPublications } from '../actions/index'
+import { fetchPublications, setState } from '../actions/index'
 import { connect } from 'react-redux'
 import GoogleAnalytics from 'react-native-google-analytics-bridge'
 import { addIndex, defaultTo, keys, map } from 'ramda'
@@ -29,9 +29,12 @@ const mapDispatchToProps = (dispatch) => ({
   fetchPublications() {
     dispatch(fetchPublications())
   },
+  setSelectedDiscipline(selected) {
+    dispatch(setState('selectedDiscipline', selected))
+  }
 })
 
-class PublicationList extends React.Component {
+export class PublicationList extends React.Component {
   constructor(props) {
     super(props)
   }
@@ -115,7 +118,11 @@ class PublicationList extends React.Component {
     return (
       <View style={styles.container}>
         { this.props.isConnected ? scrollContainer : noConnection }
-        <PublicationFilter />
+        <PublicationFilter
+          selectDiscipline = {this.props.selectedDiscipline}
+          disciplines = {this.props.disciplines}
+          setSelectedDiscipline = {this.props.setSelectedDiscipline}
+        />
       </View>
     );
   }
@@ -158,7 +165,8 @@ PublicationList.propTypes = {
   disciplines: React.PropTypes.array,
   selectedDiscipline: React.PropTypes.string,
   publications: React.PropTypes.object,
-  fetchPublications: React.PropTypes.func
+  fetchPublications: React.PropTypes.func,
+  setSelectedDiscipline: React.PropTypes.func
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PublicationList)

--- a/src/components/SideDrawerContent.js
+++ b/src/components/SideDrawerContent.js
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 })
 
-class SideDrawerContent extends Component {
+export class SideDrawerContent extends Component {
   constructor(props) {
     super(props)
     this.close = this.close.bind(this)

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 })
 
-class SignIn extends React.Component {
+export class SignIn extends React.Component {
   constructor(props) {
     super(props)
     this.state = {login: '', password: ''}
@@ -81,6 +81,10 @@ class SignIn extends React.Component {
 
   continueAsGuest() {
     this.props.continueAsGuest()
+  }
+
+  static renderNavigationBar() {
+    return <NavBar showLogo={true} showDrawer={false} />;
   }
 
   render() {

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -98,7 +98,6 @@ export class SignIn extends React.Component {
 
     return (
       <View style={styles.container}>
-        <NavBar showLogo={true} showDrawer={false} />
         <ScrollView>
           <View style={styles.signInContainer}>
             <StyledText
@@ -186,9 +185,9 @@ const styles = EStyleSheet.create({
 });
 
 SignIn.propTypes = {
-  isFetching: React.PropTypes.bool.isRequired,
-  signIn: React.PropTypes.func.isRequired,
-  continueAsGuest: React.PropTypes.func.isRequired,
+  isFetching: React.PropTypes.bool,
+  signIn: React.PropTypes.func,
+  continueAsGuest: React.PropTypes.func,
   errorMessage: React.PropTypes.string
 }
 export default connect(mapStateToProps, mapDispatchToProps)(SignIn)

--- a/src/components/__tests__/About-test.js
+++ b/src/components/__tests__/About-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import About from '../About'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <About />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -1,0 +1,25 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Button from '../Button'
+
+it('renders button text correctly', () => {
+  const tree = renderer.create(
+    <Button text={'O Hai!'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders TouchableOpacity disabled when passed in', () => {
+  const tree = renderer.create(
+    <Button disabled={true} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders styles as array when special style is passed in', () => {
+  const tree = renderer.create(
+    <Button buttonStyle={'hai'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -5,21 +5,21 @@ import Button from '../Button'
 
 it('renders button text correctly', () => {
   const tree = renderer.create(
-    <Button text={'O Hai!'} />
+    <Button text={'O Hai!'} handlePress={jest.fn} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 it('renders TouchableOpacity disabled when passed in', () => {
   const tree = renderer.create(
-    <Button disabled={true} />
+    <Button disabled={true} handlePress={jest.fn} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 it('renders styles as array when special style is passed in', () => {
   const tree = renderer.create(
-    <Button buttonStyle={'hai'} />
+    <Button buttonStyle={'hai'} handlePress={jest.fn} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/__tests__/Discipline-test.js
+++ b/src/components/__tests__/Discipline-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Discipline from '../Discipline'
+
+it('renders with a title', () => {
+  const tree = renderer.create(
+    <Discipline title='O Hai!' />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Discipline-test.js
+++ b/src/components/__tests__/Discipline-test.js
@@ -5,7 +5,12 @@ import Discipline from '../Discipline'
 
 it('renders with a title', () => {
   const tree = renderer.create(
-    <Discipline title='O Hai!' />
+    <Discipline
+      title='O Hai!'
+      icon='arts'
+      tag='test'
+      color='#fff'
+      setSelectedProjectTag={jest.fn} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/__tests__/Input-test.js
+++ b/src/components/__tests__/Input-test.js
@@ -1,0 +1,26 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Input from '../Input'
+
+
+it('renders with no label', () => {
+  const tree = renderer.create(
+    <Input />
+  ).toJSON();
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders a label correctly', () => {
+  const tree = renderer.create(
+    <Input labelText={'Ermahgerd Berks'}/>
+  ).toJSON();
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders password fields (using secureTextEntry)', () => {
+  const tree = renderer.create(
+    <Input passwordField={true}/>
+  ).toJSON();
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/NavBar-test.js
+++ b/src/components/__tests__/NavBar-test.js
@@ -1,0 +1,20 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { NavBar } from '../NavBar'
+
+const fakeUser={avatar: ''}
+
+it('renders correctly with defaults', () => {
+  const tree = renderer.create(
+    <NavBar user={fakeUser} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders correctly with title', () => {
+  const tree = renderer.create(
+    <NavBar user={fakeUser} title={'OHai'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/OverlaySpinner-test.js
+++ b/src/components/__tests__/OverlaySpinner-test.js
@@ -1,0 +1,18 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { OverlaySpinner } from '../OverlaySpinner'
+
+it('renders for isFetching', () => {
+  const tree = renderer.create(
+    <OverlaySpinner isFetching={true} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders nothing for isFetching false', () => {
+  const tree = renderer.create(
+    <OverlaySpinner isFetching={false} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Project-test.js
+++ b/src/components/__tests__/Project-test.js
@@ -1,0 +1,15 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Project from '../Project'
+
+it('renders correctly', () => {
+  const project = {
+    avatar_src: 'fake_avatar',
+    display_name: 'Nice project'
+  }
+  const tree = renderer.create(
+    <Project project={project}/>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/ProjectDiscipline-test.js
+++ b/src/components/__tests__/ProjectDiscipline-test.js
@@ -1,0 +1,20 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ProjectDisciplines } from '../ProjectDisciplines'
+
+it('renders correctly when connected', () => {
+  const user ={ display_name: 'Fake User' }
+  const tree = renderer.create(
+    <ProjectDisciplines user={user} isConnected={true} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('does not render when not connected', () => {
+  const user ={ display_name: 'Fake User' }
+  const tree = renderer.create(
+    <ProjectDisciplines user={user} isConnected={false} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/ProjectList-test.js
+++ b/src/components/__tests__/ProjectList-test.js
@@ -1,0 +1,26 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ProjectList } from '../ProjectList'
+import Project from '../Project'
+
+const project = {
+  avatar_src: 'fake_avatar',
+  display_name: 'Nice project'
+}
+
+jest.mock('ListView', () => require('react').createClass({
+    statics: {
+        DataSource: require.requireActual('ListView').DataSource,
+    },
+    render() {
+        return <Project project={project} />
+    },
+}))
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <ProjectList isConnected={true} fetchProjects={jest.fn} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Publication-test.js
+++ b/src/components/__tests__/Publication-test.js
@@ -1,0 +1,15 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Publication from '../Publication'
+
+const publication = {
+  citation: 'Nice citation'
+}
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <Publication publication={publication} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/PublicationFilter-test.js
+++ b/src/components/__tests__/PublicationFilter-test.js
@@ -1,0 +1,27 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import PublicationFilter from '../PublicationFilter'
+
+const disciplines = ['science']
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <PublicationFilter isConnected={true} disciplines={disciplines} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('does not render when not connected', () => {
+  const tree = renderer.create(
+    <PublicationFilter isConnected={false} disciplines={disciplines} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders selected discipline', () => {
+  const tree = renderer.create(
+    <PublicationFilter isConnected={false} disciplines={disciplines} selectedDiscipline={'science'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/PublicationList-test.js
+++ b/src/components/__tests__/PublicationList-test.js
@@ -1,0 +1,24 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { PublicationList } from '../PublicationList'
+
+const disciplines = ['science']
+const publications = {
+  'science': {
+    'projects': {}
+  }
+}
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <PublicationList
+      isConnected={true}
+      disciplines={disciplines}
+      selectedDiscipline={'science'}
+      publications={publications}
+      fetchPublications={jest.fn}
+    />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/SideDrawer-test.js
+++ b/src/components/__tests__/SideDrawer-test.js
@@ -1,0 +1,24 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+jest.mock('../SideDrawerContent', () => 'SideDrawerContent')
+
+jest.mock('react-native-router-flux', () => ({
+  Actions: 'Field',
+  DefaultRenderer: 'DefaultRenderer',
+}))
+
+import SideDrawer from '../SideDrawer'
+
+it('renders correctly', () => {
+  const navigationState = {
+    children: [{ }],
+    open: true
+  }
+
+  const tree = renderer.create(
+    <SideDrawer navigationState={navigationState} onNavigate={jest.fn}/>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/SideDrawerContent-test.js
+++ b/src/components/__tests__/SideDrawerContent-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { SideDrawerContent } from '../SideDrawerContent'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <SideDrawerContent />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/SignIn-test.js
+++ b/src/components/__tests__/SignIn-test.js
@@ -1,0 +1,18 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { SignIn } from '../SignIn'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <SignIn isConnected={true} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders error message', () => {
+  const tree = renderer.create(
+    <SignIn isConnected={true} errorMessage={'does not compute'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/StyledText-test.js
+++ b/src/components/__tests__/StyledText-test.js
@@ -1,0 +1,18 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import StyledText from '../StyledText'
+
+it('renders text correctly', () => {
+  const tree = renderer.create(
+    <StyledText text={'O Hai!'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders styles as array when style passed in', () => {
+  const tree = renderer.create(
+    <StyledText text={'O Hai!'}  textStyle={'test'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/UserAvatar-test.js
+++ b/src/components/__tests__/UserAvatar-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import UserAvatar from '../UserAvatar'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <UserAvatar avatar={'avatar'}/>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/ZooIcon-test.js
+++ b/src/components/__tests__/ZooIcon-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ZooIcon from '../ZooIcon'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <ZooIcon iconName={'nature'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/About-test.js.snap
+++ b/src/components/__tests__/__snapshots__/About-test.js.snap
@@ -1,0 +1,142 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <ScrollView>
+    <View
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          What is the Zooniverse?
+        </Text>
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        The Zooniverse is the world’s largest and most popular platform for people-powered research. This research is made possible by volunteers—hundreds of thousands of people around the world who come together to assist professional researchers. Our goal is to enable research that would not be possible, or practical, otherwise. Zooniverse research results in new discoveries, datasets useful to the wider research community, and many publications.
+      </Text>
+    </View>
+    <View
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          Anyone can be a researcher
+        </Text>
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        You don’t need any specialised background, training, or expertise to participate in any Zooniverse projects. We make it easy for anyone to contribute to real academic research, on their own computer, at their own convenience.
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        You’ll be able to study authentic objects of interest gathered by researchers, like images of faraway galaxies, historical records and diaries, or videos of animals in their natural habitats. By answering simple questions about them, you’ll help contribute to our understanding of our world, our history, our Universe, and more.
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        With our wide-ranging and ever-expanding suite of projects, covering many disciplines and topics across the sciences and humanities, there’s a place for anyone and everyone to explore, learn and have fun in the Zooniverse. To volunteer with us, just go to the Projects page, choose one you like the look of, and get started.
+      </Text>
+    </View>
+    <View
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          We accelerate important research by working together
+        </Text>
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        The major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition—and our ability to be surprised—makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, saving time and resources, advancing the ability of computers to do the same tasks, and leading to faster progress and understanding of the world, getting to exciting results more quickly.
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Our projects combine contributions from many individual volunteers, relying on a version of the ‘wisdom of crowds’ to produce reliable and accurate data. By having many people look at the data we often can also estimate how likely we are to make an error. The product of a Zooniverse projects is often exactly what’s needed to make progress in many fields of research.
+      </Text>
+    </View>
+    <View
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          Volunteers and professionals make real discoveries together
+        </Text>
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Zooniverse projects are constructed with the aim of converting volunteers’ efforts into measurable results. These projects have produced a large number of published research papers, as well as several open-source sets of analyzed data. In some cases, Zooniverse volunteers have even made completely unexpected and scientifically significant discoveries.
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        A significant amount of this research takes place on the Zooniverse discussion boards, where volunteers can work together with each other and with the research teams. These boards are integrated with each project to allow for everything from quick hashtagging to in-depth collaborative analysis. There is also a central Zooniverse board for general chat and discussion about Zooniverse-wide matters.
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Many of the most interesting discoveries from Zooniverse projects have come from discussion between volunteers and researchers. We encourage all users to join the conversation on the discussion boards for more in-depth participation.
+      </Text>
+    </View>
+  </ScrollView>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button-test.js.snap
@@ -1,0 +1,48 @@
+exports[`test renders TouchableOpacity disabled when passed in 1`] = `
+<TouchableOpacity
+  activeOpacity={0.5}
+  disabled={true}
+  onPress={undefined}
+  style={undefined}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined} />
+</TouchableOpacity>
+`;
+
+exports[`test renders button text correctly 1`] = `
+<TouchableOpacity
+  activeOpacity={0.5}
+  disabled={false}
+  onPress={undefined}
+  style={undefined}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined}>
+    O Hai!
+  </Text>
+</TouchableOpacity>
+`;
+
+exports[`test renders styles as array when special style is passed in 1`] = `
+<TouchableOpacity
+  activeOpacity={0.5}
+  disabled={false}
+  onPress={undefined}
+  style={
+    Array [
+      undefined,
+      undefined,
+    ]
+  }>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined} />
+</TouchableOpacity>
+`;

--- a/src/components/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button-test.js.snap
@@ -2,7 +2,7 @@ exports[`test renders TouchableOpacity disabled when passed in 1`] = `
 <TouchableOpacity
   activeOpacity={0.5}
   disabled={true}
-  onPress={undefined}
+  onPress={[Function]}
   style={undefined}>
   <Text
     accessible={true}
@@ -16,7 +16,7 @@ exports[`test renders button text correctly 1`] = `
 <TouchableOpacity
   activeOpacity={0.5}
   disabled={false}
-  onPress={undefined}
+  onPress={[Function]}
   style={undefined}>
   <Text
     accessible={true}
@@ -32,7 +32,7 @@ exports[`test renders styles as array when special style is passed in 1`] = `
 <TouchableOpacity
   activeOpacity={0.5}
   disabled={false}
-  onPress={undefined}
+  onPress={[Function]}
   style={
     Array [
       undefined,

--- a/src/components/__tests__/__snapshots__/Discipline-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Discipline-test.js.snap
@@ -1,0 +1,66 @@
+exports[`test renders with a title 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  onPress={[Function]}>
+  <View
+    style={
+      Array [
+        undefined,
+        Object {
+          "backgroundColor": undefined,
+        },
+      ]
+    }>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "zoo-font",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Array [
+              undefined,
+              undefined,
+            ],
+          ]
+        }>
+        ?
+      </Text>
+    </View>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={undefined}>
+      O Hai!
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={false}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": undefined,
+            "fontFamily": "FontAwesome",
+            "fontSize": 12,
+            "fontStyle": "normal",
+            "fontWeight": "normal",
+          },
+          undefined,
+        ]
+      }>
+      
+    </Text>
+  </View>
+</TouchableOpacity>
+`;

--- a/src/components/__tests__/__snapshots__/Discipline-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Discipline-test.js.snap
@@ -7,7 +7,7 @@ exports[`test renders with a title 1`] = `
       Array [
         undefined,
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "#fff",
         },
       ]
     }>
@@ -32,7 +32,7 @@ exports[`test renders with a title 1`] = `
             ],
           ]
         }>
-        ?
+        
       </Text>
     </View>
     <Text

--- a/src/components/__tests__/__snapshots__/Input-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Input-test.js.snap
@@ -1,0 +1,48 @@
+exports[`test renders a label correctly 1`] = `
+<View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined}>
+    Ermahgerd Berks
+  </Text>
+  <View
+    style={undefined}>
+    <TextInput
+      onChangeText={undefined}
+      returnKeyType="next"
+      secureTextEntry={false}
+      style={undefined}
+      underlineColorAndroid="white" />
+  </View>
+</View>
+`;
+
+exports[`test renders password fields (using secureTextEntry) 1`] = `
+<View>
+  <View
+    style={undefined}>
+    <TextInput
+      onChangeText={undefined}
+      returnKeyType="next"
+      secureTextEntry={true}
+      style={undefined}
+      underlineColorAndroid="white" />
+  </View>
+</View>
+`;
+
+exports[`test renders with no label 1`] = `
+<View>
+  <View
+    style={undefined}>
+    <TextInput
+      onChangeText={undefined}
+      returnKeyType="next"
+      secureTextEntry={false}
+      style={undefined}
+      underlineColorAndroid="white" />
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/NavBar-test.js.snap
+++ b/src/components/__tests__/__snapshots__/NavBar-test.js.snap
@@ -1,0 +1,90 @@
+exports[`test renders correctly with defaults 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      Object {
+        "height": 70,
+      },
+    ]
+  }>
+  <View
+    style={undefined}>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Array [
+              undefined,
+              undefined,
+            ],
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`test renders correctly with title 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      Object {
+        "height": 70,
+      },
+    ]
+  }>
+  <View
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={undefined}>
+      OHai
+    </Text>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Array [
+              undefined,
+              undefined,
+            ],
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
+++ b/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
@@ -1,0 +1,58 @@
+exports[`test renders for isFetching 1`] = `
+<View
+  style={undefined}>
+  <Modal
+    onRequestClose={[Function]}
+    transparent={true}
+    visible={true}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }>
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "bottom": 0,
+              "justifyContent": "center",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "backgroundColor": "rgba(0, 0, 0, 0.25)",
+            },
+          ]
+        }>
+        <ActivityIndicator
+          animating={true}
+          color="white"
+          hidesWhenStopped={true}
+          size="large"
+          style={
+            Object {
+              "flex": 1,
+            }
+          } />
+      </View>
+    </View>
+  </Modal>
+</View>
+`;
+
+exports[`test renders nothing for isFetching false 1`] = `
+<View
+  style={undefined}>
+  <View />
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/Project-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Project-test.js.snap
@@ -1,0 +1,46 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <Image
+    source={
+      Object {
+        "uri": "https://fake_avatar",
+      }
+    }
+    style={undefined} />
+  <TouchableOpacity
+    activeOpacity={0.5}
+    onPress={[Function]}
+    style={undefined}>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={undefined}>
+        Nice project
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </TouchableOpacity>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/ProjectDiscipline-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProjectDiscipline-test.js.snap
@@ -1,0 +1,246 @@
+exports[`test does not render when not connected 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={undefined}>
+      Fake User
+    </Text>
+  </View>
+  <View
+    style={undefined}>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        You must have an internet connection to use Zooniverse Mobile
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`test renders correctly when connected 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={undefined}>
+      Fake User
+    </Text>
+  </View>
+  <View
+    style={undefined}>
+    <ScrollView>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}>
+        <View
+          style={
+            Array [
+              undefined,
+              Object {
+                "backgroundColor": "#18807F",
+              },
+            ]
+          }>
+          <View
+            style={undefined}>
+            <Text
+              accessible={true}
+              allowFontScaling={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": undefined,
+                    "fontFamily": "zoo-font",
+                    "fontSize": 12,
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Array [
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }>
+              
+            </Text>
+          </View>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={undefined}>
+            Biology
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontFamily": "FontAwesome",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }>
+            
+          </Text>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}>
+        <View
+          style={
+            Array [
+              undefined,
+              Object {
+                "backgroundColor": "#46D178",
+              },
+            ]
+          }>
+          <View
+            style={undefined}>
+            <Text
+              accessible={true}
+              allowFontScaling={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": undefined,
+                    "fontFamily": "zoo-font",
+                    "fontSize": 12,
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Array [
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }>
+              
+            </Text>
+          </View>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={undefined}>
+            Nature
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontFamily": "FontAwesome",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }>
+            
+          </Text>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}>
+        <View
+          style={
+            Array [
+              undefined,
+              Object {
+                "backgroundColor": "#512BAD",
+              },
+            ]
+          }>
+          <View
+            style={undefined}>
+            <Text
+              accessible={true}
+              allowFontScaling={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": undefined,
+                    "fontFamily": "zoo-font",
+                    "fontSize": 12,
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Array [
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }>
+              
+            </Text>
+          </View>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={undefined}>
+            Space
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontFamily": "FontAwesome",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }>
+            
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </ScrollView>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/ProjectList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProjectList-test.js.snap
@@ -1,0 +1,52 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <View
+      style={undefined}>
+      <Image
+        source={
+          Object {
+            "uri": "https://fake_avatar",
+          }
+        }
+        style={undefined} />
+      <TouchableOpacity
+        activeOpacity={0.5}
+        onPress={[Function]}
+        style={undefined}>
+        <View
+          style={undefined}>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={undefined}>
+            Nice project
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontFamily": "FontAwesome",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }>
+            
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/Publication-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Publication-test.js.snap
@@ -1,0 +1,42 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <TouchableOpacity
+    activeOpacity={0.5}
+    onPress={[Function]}>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        Nice citation
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </View>
+  </TouchableOpacity>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/PublicationFilter-test.js.snap
+++ b/src/components/__tests__/__snapshots__/PublicationFilter-test.js.snap
@@ -1,0 +1,140 @@
+exports[`test does not render when not connected 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      false,
+    ]
+  }>
+  <View
+    style={undefined}>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={[Function]}
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Choose Category
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontFamily": "FontAwesome",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }>
+          
+        </Text>
+      </View>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`test renders correctly 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      false,
+    ]
+  }>
+  <View
+    style={undefined}>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={[Function]}
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Choose Category
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontFamily": "FontAwesome",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }>
+          
+        </Text>
+      </View>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`test renders selected discipline 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      false,
+    ]
+  }>
+  <View
+    style={undefined}>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={[Function]}
+      style={undefined}>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Viewing Science
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontFamily": "FontAwesome",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }>
+          
+        </Text>
+      </View>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/PublicationList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/PublicationList-test.js.snap
@@ -1,0 +1,55 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <ScrollView>
+    <View
+      style={undefined}>
+      <View />
+    </View>
+  </ScrollView>
+  <View
+    style={
+      Array [
+        undefined,
+        false,
+      ]
+    }>
+    <View
+      style={undefined}>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        onPress={[Function]}
+        style={undefined}>
+        <View
+          style={undefined}>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={undefined}>
+            Choose Category
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontFamily": "FontAwesome",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }>
+            
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/SideDrawer-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SideDrawer-test.js.snap
@@ -1,0 +1,108 @@
+exports[`test renders correctly 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }>
+  <View
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    style={
+      Array [
+        Object {
+          "borderWidth": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": 667,
+          "width": 378,
+        },
+      ]
+    }>
+    <DefaultRenderer
+      navigationState={Object {}}
+      onNavigate={[Function]} />
+    <View
+      pointerEvents="auto"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      } />
+  </View>
+  <View
+    elevation={0}
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "white",
+          "borderWidth": 0,
+          "elevation": 3,
+          "position": "absolute",
+          "right": 0,
+          "shadowColor": "black",
+          "shadowOpacity": 0.8,
+          "shadowRadius": 3,
+          "top": 0,
+        },
+        Object {
+          "height": 667,
+          "width": 262.5,
+        },
+      ]
+    }>
+    <SideDrawerContent />
+    <View
+      pointerEvents="none"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      } />
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/SideDrawerContent-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SideDrawerContent-test.js.snap
@@ -1,0 +1,187 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <TouchableOpacity
+    activeOpacity={0.5}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={false}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": undefined,
+            "fontFamily": "FontAwesome",
+            "fontSize": 12,
+            "fontStyle": "normal",
+            "fontWeight": "normal",
+          },
+          undefined,
+        ]
+      }>
+      
+    </Text>
+  </TouchableOpacity>
+  <TouchableOpacity
+    activeOpacity={0.2}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      Home
+    </Text>
+  </TouchableOpacity>
+  <TouchableOpacity
+    activeOpacity={0.2}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      About
+    </Text>
+  </TouchableOpacity>
+  <TouchableOpacity
+    activeOpacity={0.2}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      Publications
+    </Text>
+  </TouchableOpacity>
+  <TouchableOpacity
+    activeOpacity={0.2}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      Sign Out
+    </Text>
+  </TouchableOpacity>
+  <View
+    style={undefined}>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/SignIn-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SignIn-test.js.snap
@@ -1,0 +1,283 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      SIGN IN
+    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Username or Email Address
+      </Text>
+      <View
+        style={undefined}>
+        <TextInput
+          onChangeText={[Function]}
+          returnKeyType="next"
+          secureTextEntry={false}
+          style={undefined}
+          underlineColorAndroid="white" />
+      </View>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Password
+      </Text>
+      <View
+        style={undefined}>
+        <TextInput
+          onChangeText={[Function]}
+          returnKeyType="next"
+          secureTextEntry={true}
+          style={undefined}
+          underlineColorAndroid="white" />
+      </View>
+    </View>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        Forget your password?
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={true}
+      onPress={[Function]}
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Sign In
+      </Text>
+    </TouchableOpacity>
+    <View
+      style={undefined}>
+      <View
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        OR
+      </Text>
+      <View
+        style={undefined} />
+    </View>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={false}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Continue without signing in
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Register for account
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`test renders error message 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      SIGN IN
+    </Text>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Username or Email Address
+      </Text>
+      <View
+        style={undefined}>
+        <TextInput
+          onChangeText={[Function]}
+          returnKeyType="next"
+          secureTextEntry={false}
+          style={undefined}
+          underlineColorAndroid="white" />
+      </View>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Password
+      </Text>
+      <View
+        style={undefined}>
+        <TextInput
+          onChangeText={[Function]}
+          returnKeyType="next"
+          secureTextEntry={true}
+          style={undefined}
+          underlineColorAndroid="white" />
+      </View>
+    </View>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      does not compute
+    </Text>
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[Function]}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        Forget your password?
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={true}
+      onPress={[Function]}
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Sign In
+      </Text>
+    </TouchableOpacity>
+    <View
+      style={undefined}>
+      <View
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        OR
+      </Text>
+      <View
+        style={undefined} />
+    </View>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={false}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Continue without signing in
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={undefined}>
+        Register for account
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/SignIn-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SignIn-test.js.snap
@@ -1,59 +1,9 @@
 exports[`test renders correctly 1`] = `
 <View
   style={undefined}>
-  <View
-    style={undefined}>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      SIGN IN
-    </Text>
-    <View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Username or Email Address
-      </Text>
-      <View
-        style={undefined}>
-        <TextInput
-          onChangeText={[Function]}
-          returnKeyType="next"
-          secureTextEntry={false}
-          style={undefined}
-          underlineColorAndroid="white" />
-      </View>
-    </View>
-    <View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Password
-      </Text>
-      <View
-        style={undefined}>
-        <TextInput
-          onChangeText={[Function]}
-          returnKeyType="next"
-          secureTextEntry={true}
-          style={undefined}
-          underlineColorAndroid="white" />
-      </View>
-    </View>
-    <TouchableOpacity
-      activeOpacity={0.2}
-      onPress={[Function]}>
+  <ScrollView>
+    <View
+      style={undefined}>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -64,144 +14,135 @@ exports[`test renders correctly 1`] = `
             undefined,
           ]
         }>
-        Forget your password?
+        SIGN IN
       </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={true}
-      onPress={[Function]}
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Username or Email Address
+        </Text>
+        <View
+          style={undefined}>
+          <TextInput
+            onChangeText={[Function]}
+            returnKeyType="next"
+            secureTextEntry={false}
+            style={undefined}
+            underlineColorAndroid="white" />
+        </View>
+      </View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Password
+        </Text>
+        <View
+          style={undefined}>
+          <TextInput
+            onChangeText={[Function]}
+            returnKeyType="next"
+            secureTextEntry={true}
+            style={undefined}
+            underlineColorAndroid="white" />
+        </View>
+      </View>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
         style={undefined}>
-        Sign In
-      </Text>
-    </TouchableOpacity>
-    <View
-      style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          Forget your password?
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={true}
+        onPress={[Function]}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Sign In
+        </Text>
+      </TouchableOpacity>
       <View
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
         style={undefined}>
-        OR
-      </Text>
-      <View
-        style={undefined} />
+        <View
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          OR
+        </Text>
+        <View
+          style={undefined} />
+      </View>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={false}
+        onPress={[Function]}
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Continue without signing in
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={false}
+        onPress={[Function]}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Register for account
+        </Text>
+      </TouchableOpacity>
     </View>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={false}
-      onPress={[Function]}
-      style={undefined}>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Continue without signing in
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={false}
-      onPress={[Function]}
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Register for account
-      </Text>
-    </TouchableOpacity>
-  </View>
+  </ScrollView>
 </View>
 `;
 
 exports[`test renders error message 1`] = `
 <View
   style={undefined}>
-  <View
-    style={undefined}>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      SIGN IN
-    </Text>
-    <View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Username or Email Address
-      </Text>
-      <View
-        style={undefined}>
-        <TextInput
-          onChangeText={[Function]}
-          returnKeyType="next"
-          secureTextEntry={false}
-          style={undefined}
-          underlineColorAndroid="white" />
-      </View>
-    </View>
-    <View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Password
-      </Text>
-      <View
-        style={undefined}>
-        <TextInput
-          onChangeText={[Function]}
-          returnKeyType="next"
-          secureTextEntry={true}
-          style={undefined}
-          underlineColorAndroid="white" />
-      </View>
-    </View>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      does not compute
-    </Text>
-    <TouchableOpacity
-      activeOpacity={0.2}
-      onPress={[Function]}>
+  <ScrollView>
+    <View
+      style={undefined}>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -212,72 +153,137 @@ exports[`test renders error message 1`] = `
             undefined,
           ]
         }>
-        Forget your password?
+        SIGN IN
       </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={true}
-      onPress={[Function]}
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Username or Email Address
+        </Text>
+        <View
+          style={undefined}>
+          <TextInput
+            onChangeText={[Function]}
+            returnKeyType="next"
+            secureTextEntry={false}
+            style={undefined}
+            underlineColorAndroid="white" />
+        </View>
+      </View>
+      <View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Password
+        </Text>
+        <View
+          style={undefined}>
+          <TextInput
+            onChangeText={[Function]}
+            returnKeyType="next"
+            secureTextEntry={true}
+            style={undefined}
+            underlineColorAndroid="white" />
+        </View>
+      </View>
       <Text
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}>
-        Sign In
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        does not compute
       </Text>
-    </TouchableOpacity>
-    <View
-      style={undefined}>
-      <View
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
         style={undefined}>
-        OR
-      </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              undefined,
+            ]
+          }>
+          Forget your password?
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={true}
+        onPress={[Function]}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Sign In
+        </Text>
+      </TouchableOpacity>
       <View
-        style={undefined} />
+        style={undefined}>
+        <View
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          OR
+        </Text>
+        <View
+          style={undefined} />
+      </View>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={false}
+        onPress={[Function]}
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Continue without signing in
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        disabled={false}
+        onPress={[Function]}
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={undefined}>
+          Register for account
+        </Text>
+      </TouchableOpacity>
     </View>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={false}
-      onPress={[Function]}
-      style={undefined}>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Continue without signing in
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      activeOpacity={0.5}
-      disabled={false}
-      onPress={[Function]}
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={undefined}>
-        Register for account
-      </Text>
-    </TouchableOpacity>
-  </View>
+  </ScrollView>
 </View>
 `;

--- a/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,24 @@
+exports[`test renders styles as array when style passed in 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      undefined,
+      undefined,
+    ]
+  }>
+  O Hai!
+</Text>
+`;
+
+exports[`test renders text correctly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={undefined}>
+  O Hai!
+</Text>
+`;

--- a/src/components/__tests__/__snapshots__/UserAvatar-test.js.snap
+++ b/src/components/__tests__/__snapshots__/UserAvatar-test.js.snap
@@ -1,0 +1,9 @@
+exports[`test renders correctly 1`] = `
+<Image
+  source={
+    Object {
+      "uri": "avatar",
+    }
+  }
+  style={undefined} />
+`;

--- a/src/components/__tests__/__snapshots__/ZooIcon-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ZooIcon-test.js.snap
@@ -1,0 +1,23 @@
+exports[`test renders correctly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={false}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      Object {
+        "color": undefined,
+        "fontFamily": "zoo-font",
+        "fontSize": 12,
+        "fontStyle": "normal",
+        "fontWeight": "normal",
+      },
+      Array [
+        undefined,
+        undefined,
+      ],
+    ]
+  }>
+  
+</Text>
+`;

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -36,7 +36,7 @@ export default class App extends Component {
         <Router ref="router">
           <Scene ref="drawer" key="drawer" component={SideDrawer} open={false}>
             <Scene key="main" tabs={false} >
-              <Scene key="SignIn" hideNavBar={true} component={SignIn} type="reset" />
+              <Scene key="SignIn" component={SignIn} type="reset" />
               <Scene key="ZooniverseApp" component={ZooniverseApp} initial />
               <Scene key="ProjectDisciplines" component={ProjectDisciplines} />
               <Scene key="About" component={About} />

--- a/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
+++ b/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
@@ -1,0 +1,47 @@
+exports[`test sets a new state 1`] = `
+Object {
+  "bobLoblaw": "Has a law blog",
+  "errorMessage": null,
+  "isConnected": null,
+  "isFetching": false,
+  "projectList": Array [],
+  "selectedDiscipline": null,
+  "user": Object {},
+}
+`;
+
+exports[`test sets state from initial state 1`] = `
+Object {
+  "errorMessage": null,
+  "isConnected": true,
+  "isFetching": false,
+  "projectList": Array [],
+  "selectedDiscipline": null,
+  "user": Object {},
+}
+`;
+
+exports[`test sets user 1`] = `
+Object {
+  "errorMessage": null,
+  "isConnected": null,
+  "isFetching": false,
+  "projectList": Array [],
+  "selectedDiscipline": null,
+  "user": Object {
+    "avatar": "Some avatar",
+    "display_name": "Me",
+  },
+}
+`;
+
+exports[`test unsets user 1`] = `
+Object {
+  "errorMessage": null,
+  "isConnected": null,
+  "isFetching": false,
+  "projectList": Array [],
+  "selectedDiscipline": null,
+  "user": Object {},
+}
+`;

--- a/src/reducers/__tests__/reducers-test.js
+++ b/src/reducers/__tests__/reducers-test.js
@@ -1,0 +1,20 @@
+import 'react-native'
+import reducers, { initialState } from '../index.js'
+import { setUser, setState } from '../../actions/index'
+
+it('sets user', () => {
+  let fakeUser = { avatar: 'Some avatar', display_name: 'Me'}
+  expect(reducers(initialState, setUser(fakeUser))).toMatchSnapshot()
+})
+
+it('unsets user', () => {
+  expect(reducers(initialState, setUser({}))).toMatchSnapshot()
+})
+
+it('sets state from initial state', () => {
+  expect(reducers(initialState, setState('isConnected', true))).toMatchSnapshot()
+})
+
+it('sets a new state', () => {
+  expect(reducers(initialState, setState('bobLoblaw', 'Has a law blog'))).toMatchSnapshot()
+})


### PR DESCRIPTION
Add tests using jest's snapshot for components and reducers.  
More info:
https://facebook.github.io/jest/docs/tutorial-react-native.html

A few updates to existing components were also made to make them more easily testable:
  *  Exporting "undecorated" components so that the redux connect to provider isn't required to test
  *  Move logic and redux store from PublicationFilter to PublicationList, to simplify that component and so that it doesn't have to be mocked as a child component with the redux store connection
  *  Move render of nav bar on signin to use the static function like the other components (to make it work the same as other components and remove the need to mock)

(also updates readme)
Fixes #40 