### PR TITLE
Open project directly from project-specific push notification

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -145,6 +145,8 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-fcm')
+    compile 'com.android.support:support-v4:23.0.+'
     compile 'com.android.support:multidex:1.0.0'
     compile project(':react-native-svg')
     compile project(':react-native-google-analytics-bridge')
@@ -166,4 +168,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
   into 'libs'
 }
 
+apply plugin: "com.android.application"
 apply plugin: 'com.google.gms.google-services'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
       <activity
         android:name=".MainActivity"
         android:label="Zooniverse"
+        android:launchMode="singleTop"
+        android:showOnLockScreen="true"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
@@ -47,7 +49,6 @@
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
             </intent-filter>
         </service>
-
 
     </application>
 

--- a/android/app/src/main/java/com/zooniversemobile/MainApplication.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplication.java
@@ -2,6 +2,7 @@ package com.zooniversemobile;
 
 import android.support.multidex.MultiDexApplication;
 
+import com.evollu.react.fcm.FIRMessagingPackage;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -27,7 +28,8 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
           new MainReactPackage(),
           new GoogleAnalyticsBridgePackage(),
           new WebViewBridgePackage(),
-          new RNSvgPackage()
+          new RNSvgPackage(),
+          new FIRMessagingPackage()
       );
     }
   };

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,7 +1,8 @@
 rootProject.name = 'ZooniverseMobile'
 
-include ':react-native-google-analytics-bridge', ':react-native-orientation', ':react-native-webview-bridge', ':react-native-svg', ':app'
+include ':react-native-google-analytics-bridge', ':react-native-orientation', ':react-native-fcm', ':react-native-svg', ':react-native-webview-bridge', ':app'
 project(':react-native-orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')
 project(':react-native-google-analytics-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-analytics-bridge/android')
-project(':react-native-webview-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview-bridge/android')
+project(':react-native-fcm').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fcm/android')
 project(':react-native-svg').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-svg/android')
+project(':react-native-webview-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview-bridge/android')

--- a/ios/ZooniverseMobile.xcodeproj/project.pbxproj
+++ b/ios/ZooniverseMobile.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		999F9C8B1DB7B4FA002B6AF0 /* OpenSans-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C801DB7B4FA002B6AF0 /* OpenSans-Semibold.ttf */; };
 		999F9C8C1DB7B4FA002B6AF0 /* OpenSans-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C811DB7B4FA002B6AF0 /* OpenSans-SemiboldItalic.ttf */; };
 		999F9C8D1DB7B4FA002B6AF0 /* zoo-font.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C821DB7B4FA002B6AF0 /* zoo-font.ttf */; };
+		99D806C21DF1D6F300106B56 /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99D806BF1DF1D6D400106B56 /* libRCTPushNotification.a */; };
 		99E051D41D7F633400052983 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99E051D31D7F633400052983 /* CoreData.framework */; };
 		99E051D61D7F633F00052983 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99E051D51D7F633F00052983 /* SystemConfiguration.framework */; };
 		99E051D81D7F634900052983 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 99E051D71D7F634900052983 /* libz.tbd */; };
@@ -195,6 +196,69 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTOrientation;
 		};
+		99D806971DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A283A1D9B042B00D4039D;
+			remoteInfo = "RCTImage-tvOS";
+		};
+		99D8069B1DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28471D9B043800D4039D;
+			remoteInfo = "RCTLinking-tvOS";
+		};
+		99D8069F1DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28541D9B044C00D4039D;
+			remoteInfo = "RCTNetwork-tvOS";
+		};
+		99D806AA1DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28611D9B046600D4039D;
+			remoteInfo = "RCTSettings-tvOS";
+		};
+		99D806AE1DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A287B1D9B048500D4039D;
+			remoteInfo = "RCTText-tvOS";
+		};
+		99D806B31DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28881D9B049200D4039D;
+			remoteInfo = "RCTWebSocket-tvOS";
+		};
+		99D806B71DF1D6C400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28131D9B038B00D4039D;
+			remoteInfo = "React-tvOS";
+		};
+		99D806BE1DF1D6D400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 99D806B91DF1D6D400106B56 /* RCTPushNotification.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTPushNotification;
+		};
+		99D806C01DF1D6D400106B56 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 99D806B91DF1D6D400106B56 /* RCTPushNotification.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2DD0EFE61DA8533A00B0C975;
+			remoteInfo = "RCTPushNotification-tvOS";
+		};
 		99E051C81D7F618700052983 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F43970FF5E9A46EBB8722FC8 /* RCTGoogleAnalyticsBridge.xcodeproj */;
@@ -247,6 +311,7 @@
 		999F9C821DB7B4FA002B6AF0 /* zoo-font.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "zoo-font.ttf"; sourceTree = "<group>"; };
 		99B247C07D08CC4E84220651 /* Pods-ZooniverseMobile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZooniverseMobile.release.xcconfig"; path = "Pods/Target Support Files/Pods-ZooniverseMobile/Pods-ZooniverseMobile.release.xcconfig"; sourceTree = "<group>"; };
 		99C686741D958DE000FF0CB2 /* ZooniverseMobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ZooniverseMobile.entitlements; path = ZooniverseMobile/ZooniverseMobile.entitlements; sourceTree = "<group>"; };
+		99D806B91DF1D6D400106B56 /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		99E051D31D7F633400052983 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		99E051D51D7F633F00052983 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		99E051D71D7F634900052983 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -286,6 +351,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				99D806C21DF1D6F300106B56 /* libRCTPushNotification.a in Frameworks */,
 				2202F9D9A1D04E919F02ECA5 /* libRCTOrientation.a in Frameworks */,
 				11F09CB859174EC788E83797 /* libRCTGoogleAnalyticsBridge.a in Frameworks */,
 				14F7F9D4AAA6EEC2AF1F4830 /* libPods-ZooniverseMobile.a in Frameworks */,
@@ -315,7 +381,7 @@
 			isa = PBXGroup;
 			children = (
 				00C302C01ABCB91800DB3ED1 /* libRCTImage.a */,
-				995543731DE3624E0016257B /* libRCTImage-tvOS.a */,
+				99D806981DF1D6C400106B56 /* libRCTImage-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -324,7 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */,
-				9955437B1DE3624E0016257B /* libRCTNetwork-tvOS.a */,
+				99D806A01DF1D6C400106B56 /* libRCTNetwork-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -358,7 +424,7 @@
 			isa = PBXGroup;
 			children = (
 				139105C11AF99BAD00B5F7CC /* libRCTSettings.a */,
-				995543801DE3624E0016257B /* libRCTSettings-tvOS.a */,
+				99D806AB1DF1D6C400106B56 /* libRCTSettings-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -367,7 +433,7 @@
 			isa = PBXGroup;
 			children = (
 				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
-				995543891DE3624E0016257B /* libRCTWebSocket-tvOS.a */,
+				99D806B41DF1D6C400106B56 /* libRCTWebSocket-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -391,7 +457,7 @@
 			isa = PBXGroup;
 			children = (
 				146834041AC3E56700842450 /* libReact.a */,
-				9955438D1DE3624E0016257B /* libReact-tvOS.a */,
+				99D806B81DF1D6C400106B56 /* libReact-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -400,7 +466,7 @@
 			isa = PBXGroup;
 			children = (
 				78C398B91ACF4ADC00677621 /* libRCTLinking.a */,
-				995543771DE3624E0016257B /* libRCTLinking-tvOS.a */,
+				99D8069C1DF1D6C400106B56 /* libRCTLinking-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -410,6 +476,7 @@
 			children = (
 				99911C641E098FE2000A70D3 /* React-Native-Webview-Bridge.xcodeproj */,
 				9955436A1DE3624E0016257B /* RNSVG.xcodeproj */,
+				99D806B91DF1D6D400106B56 /* RCTPushNotification.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
@@ -430,7 +497,7 @@
 			isa = PBXGroup;
 			children = (
 				832341B51AAA6A8300B99B32 /* libRCTText.a */,
-				995543841DE3624E0016257B /* libRCTText-tvOS.a */,
+				99D806AF1DF1D6C400106B56 /* libRCTText-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -502,6 +569,15 @@
 			isa = PBXGroup;
 			children = (
 				99AC04511D7626D400E303A3 /* libRCTOrientation.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		99D806BA1DF1D6D400106B56 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				99D806BF1DF1D6D400106B56 /* libRCTPushNotification.a */,
+				99D806C11DF1D6D400106B56 /* libRCTPushNotification-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -592,6 +668,9 @@
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = 888MXXMABP;
 						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
 							com.apple.Push = {
 								enabled = 1;
 							};
@@ -638,6 +717,10 @@
 				{
 					ProductGroup = 99AC04481D7626D400E303A3 /* Products */;
 					ProjectRef = 0078DB4906E643B2AE48F0C5 /* RCTOrientation.xcodeproj */;
+				},
+				{
+					ProductGroup = 99D806BA1DF1D6D400106B56 /* Products */;
+					ProjectRef = 99D806B91DF1D6D400106B56 /* RCTPushNotification.xcodeproj */;
 				},
 				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
@@ -815,6 +898,69 @@
 			fileType = archive.ar;
 			path = libRCTOrientation.a;
 			remoteRef = 99AC04501D7626D400E303A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806981DF1D6C400106B56 /* libRCTImage-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTImage-tvOS.a";
+			remoteRef = 99D806971DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D8069C1DF1D6C400106B56 /* libRCTLinking-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTLinking-tvOS.a";
+			remoteRef = 99D8069B1DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806A01DF1D6C400106B56 /* libRCTNetwork-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTNetwork-tvOS.a";
+			remoteRef = 99D8069F1DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806AB1DF1D6C400106B56 /* libRCTSettings-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTSettings-tvOS.a";
+			remoteRef = 99D806AA1DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806AF1DF1D6C400106B56 /* libRCTText-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTText-tvOS.a";
+			remoteRef = 99D806AE1DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806B41DF1D6C400106B56 /* libRCTWebSocket-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTWebSocket-tvOS.a";
+			remoteRef = 99D806B31DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806B81DF1D6C400106B56 /* libReact-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libReact-tvOS.a";
+			remoteRef = 99D806B71DF1D6C400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806BF1DF1D6D400106B56 /* libRCTPushNotification.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTPushNotification.a;
+			remoteRef = 99D806BE1DF1D6D400106B56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		99D806C11DF1D6D400106B56 /* libRCTPushNotification-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTPushNotification-tvOS.a";
+			remoteRef = 99D806C01DF1D6D400106B56 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		99E051C91D7F618700052983 /* libRCTGoogleAnalyticsBridge.a */ = {
@@ -1030,6 +1176,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/PushNotificationIOS/**",
 				);
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1062,6 +1209,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/PushNotificationIOS/**",
 				);
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/ZooniverseMobile/AppDelegate.m
+++ b/ios/ZooniverseMobile/AppDelegate.m
@@ -13,6 +13,7 @@
 #import "RCTBundleURLProvider.h"
 #import "RCTRootView.h"
 
+#import "RCTPushNotificationManager.h"
 #import <Pusher/Pusher.h>
 
 @import HockeySDK;
@@ -39,16 +40,7 @@
   }
   else
   {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    center.delegate = self;
-    [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error)
-    {
-      if( !error )
-      {
-        [[UIApplication sharedApplication] registerForRemoteNotifications];  // required to get the app to do anything at all about push notifications
-        NSLog( @"Push registration success." );
-      }
-    }];
+    [self registerForRemoteNotifications];
   }
 
   [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:@"a64221f0d73b46829478d405c90e6638"];
@@ -75,8 +67,20 @@
   return YES;
 }
 
+
 - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
   return [Orientation getOrientation];
+}
+
+- (void)registerForRemoteNotifications {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    center.delegate = self;
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error){
+      if(!error){
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+      }
+    }];
+
 }
 
 
@@ -85,21 +89,22 @@
   [[[self pusher] nativePusher] subscribe:@"general"];
 }
 
+
+//For iOS < 10
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-  NSLog(@"Received remote notification: %@", notification);
+  [RCTPushNotificationManager didReceiveRemoteNotification:notification];
 }
 
 
+//For iOS >= 10 - Called when a notification is delivered to a foreground app.
 -(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler{
-  
-  NSLog(@"Userinfo %@",notification.request.content.userInfo);
-  
+  completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
 }
 
+//For iOS >= 10 - Called to let your app know which action was selected by the user for a given notification.
 -(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void(^)())completionHandler{
-  
-  NSLog(@"Userinfo %@",response.notification.request.content.userInfo);
-  
+  [RCTPushNotificationManager didReceiveRemoteNotification:response.notification.request.content.userInfo];
+  completionHandler();
 }
 
 @end

--- a/ios/ZooniverseMobile/Info.plist
+++ b/ios/ZooniverseMobile/Info.plist
@@ -15,6 +15,10 @@
 		<string>zoo-font.ttf</string>
 		<string>FontAwesome.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+	  <string>remote-notification</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-native-checkbox-field": "^1.1.2",
     "react-native-drawer": "^2.3.0",
     "react-native-extended-stylesheet": "^0.3.0",
+    "react-native-fcm": "^2.5.0",
     "react-native-google-analytics-bridge": "^4.0.2",
     "react-native-loading-spinner-overlay": "^0.3.0",
     "react-native-orientation": "^1.17.0",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -56,7 +56,7 @@ export function checkIsConnected() {
 export function fetchProjects() {
   return dispatch => {
     dispatch(setError(''))
-    var callFetchProjects = tag => dispatch(fetchProjectsByTag(tag.value))
+    let callFetchProjects = tag => dispatch(fetchProjectsByTag(tag.value))
     forEach(callFetchProjects, filter(propEq('display', true), GLOBALS.DISCIPLINES))
   }
 }
@@ -99,5 +99,15 @@ export function fetchPublications() {
         PUBLICATIONS[key]
       )
     }, keys(PUBLICATIONS))
+  }
+}
+
+export function fetchNotificationProject(projectID) {
+  return dispatch => {
+    apiClient.type('projects').get({id: projectID}).then((projects) => {
+      dispatch(setState('notificationProject', head(projects)))
+    }).catch((error) => {
+      dispatch(setError('The following error occurred.  Please close down Zooniverse and try again.  If it persists please notify us.  \n\n' + error,))
+    })
   }
 }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -46,6 +46,9 @@ const styles = EStyleSheet.create({
   disabledRegisterButton: {
     backgroundColor: '$registerDisabledButtonColor'
   },
+  greyButton: {
+    backgroundColor: '$mediumGrey',
+  },
 });
 
 Button.propTypes = {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -46,8 +46,8 @@ const styles = EStyleSheet.create({
   disabledRegisterButton: {
     backgroundColor: '$registerDisabledButtonColor'
   },
-  greyButton: {
-    backgroundColor: '$mediumGrey',
+  navyButton: {
+    backgroundColor: '$navy',
   },
 });
 

--- a/src/components/NotificationModal.js
+++ b/src/components/NotificationModal.js
@@ -1,0 +1,144 @@
+import React, { Component } from 'react'
+import {
+  Alert,
+  Linking,
+  Platform,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import StyledModal from './StyledModal'
+import StyledText from './StyledText'
+import Button from './Button'
+import { connect } from 'react-redux'
+import { fetchNotificationProject } from '../actions/index'
+import { MOBILE_PROJECTS } from '../constants/mobile_projects'
+import { indexOf, isEmpty } from 'ramda'
+import GoogleAnalytics from 'react-native-google-analytics-bridge'
+
+
+let notificationTitle, notificationBody, projectID
+
+const mapStateToProps = (state) => ({
+  notificationProject: state.notificationProject,
+  notificationPayload: state.notificationPayload
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  fetchNotificationProject(projectID) {
+    dispatch(fetchNotificationProject(projectID))
+  },
+})
+
+class NotificationModal extends Component {
+  constructor(props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props !== nextProps) {
+      const notification = this.props.notificationPayload
+      if (Platform.OS === 'ios'){
+        if (notification._alert !== undefined) {
+          notificationTitle = notification._alert.title
+          notificationBody = notification._alert.body
+          projectID = ( notification._data.data !== undefined ? notification._data.data.project_id : null)
+        }
+      } else {
+        notificationTitle = notification.title
+        notificationBody = notification.body
+        projectID = notification.project_id
+      }
+
+      if (this.isMobileProject(projectID)) {
+        this.props.fetchNotificationProject(projectID)
+      }
+    }
+  }
+
+  isMobileProject(projectID) {
+    return indexOf(projectID, MOBILE_PROJECTS) >= 0
+  }
+
+  handleClick() {
+    GoogleAnalytics.trackEvent('view from notification', this.props.notificationProject.display_name)
+
+    const zurl=`http://zooniverse.org/projects/${this.props.notificationProject.slug}`
+    Linking.canOpenURL(zurl).then(supported => {
+      if (supported) {
+        Linking.openURL(zurl);
+      } else {
+        Alert.alert(
+          'Error',
+          'Sorry, but it looks like you are unable to open the project in your default browser.',
+        )
+      }
+    })
+  }
+
+  render() {
+    const projectDisplay =
+      <View style={styles.projectContainer}>
+          <StyledText additionalStyles={[styles.subheader]} text={`About ${this.props.notificationProject.display_name}`} />
+          <StyledText additionalStyles={[styles.smallText]}  text={this.props.notificationProject.description} />
+
+          <View style={styles.container}>
+            <Button
+              handlePress={this.handleClick}
+              text={'Visit this project'} />
+          </View>
+      </View>
+
+    return (
+      <StyledModal
+        isVisible={this.props.isVisible}
+        setVisibility={this.props.setVisibility}>
+
+        <StyledText
+          textStyle='largeBold'
+          text={notificationTitle} />
+
+        <View style={styles.container}>
+          <StyledText
+            text={notificationBody} />
+        </View>
+
+        { (isEmpty(this.props.notificationProject) || (isEmpty(projectID))) ? null : projectDisplay }
+
+        <Button
+          handlePress={() => this.props.setVisibility(false)}
+          buttonStyle={'greyButton'}
+          text={'Close'} />
+
+      </StyledModal>
+    )
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    paddingTop: 10,
+    paddingBottom: 10,
+  },
+  projectContainer: {
+    marginTop: 20,
+  },
+  subheader: {
+    fontStyle: 'italic',
+    fontSize: 16
+  },
+  smallText: {
+    fontSize: 13,
+    lineHeight: 20
+  }
+})
+
+NotificationModal.propTypes = {
+  notificationPayload: React.PropTypes.object,
+  notificationProject: React.PropTypes.object,
+  isVisible: React.PropTypes.bool,
+  setVisibility: React.PropTypes.func,
+  fetchNotificationProject: React.PropTypes.func,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotificationModal)

--- a/src/components/NotificationModal.js
+++ b/src/components/NotificationModal.js
@@ -107,7 +107,7 @@ class NotificationModal extends Component {
 
         <Button
           handlePress={() => this.props.setVisibility(false)}
-          buttonStyle={'greyButton'}
+          buttonStyle={'navyButton'}
           text={'Close'} />
 
       </StyledModal>

--- a/src/components/StyledModal.js
+++ b/src/components/StyledModal.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import {
+  Modal,
+  ScrollView,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import Icon from 'react-native-vector-icons/FontAwesome'
+
+class StyledModal extends Component {
+  render() {
+    return (
+      <View>
+        <Modal
+          animationType={'fade'}
+          transparent={true}
+          onRequestClose={() => {}}
+          visible={this.props.isVisible}>
+          <View style={styles.container}>
+            <ScrollView contentContainerStyle={styles.innerContainer}>
+              { this.props.children }
+            </ScrollView>
+          </View>
+          <TouchableOpacity
+            activeOpacity={0.5}
+            onPress={() => this.props.setVisibility(false)}
+            style={styles.closeIcon}>
+            <Icon name="times" style={styles.icon} />
+          </TouchableOpacity>
+        </Modal>
+
+      </View>
+    )
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    flex: 1,
+    justifyContent: 'flex-start',
+    padding: 20,
+  },
+  innerContainer: {
+    alignItems: 'flex-start',
+    backgroundColor: 'white',
+    borderRadius: 4,
+    marginTop: 40,
+    padding: 24,
+  },
+  icon: {
+    backgroundColor: 'transparent',
+    color: 'white',
+    fontSize: 24,
+    padding: 15,
+  },
+  closeIcon: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    top: 13,
+    right: 13
+  }
+})
+
+StyledModal.propTypes = {
+  children: React.PropTypes.array,
+  isVisible: React.PropTypes.bool,
+  setVisibility: React.PropTypes.func
+}
+
+export default StyledModal

--- a/src/components/StyledText.js
+++ b/src/components/StyledText.js
@@ -3,9 +3,11 @@ import {
   Text
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
+import { append } from 'ramda'
 
 const StyledText = (props) => {
-  const textStyle = ( props.textStyle ? [styles.defaultText, styles[props.textStyle]] : styles.defaultText )
+  let textStyle = ( props.textStyle ? [styles.defaultText, styles[props.textStyle]] : [styles.defaultText] )
+  textStyle = (props.additionalStyles ? append(props.additionalStyles, textStyle) : textStyle)
 
   return (
     <Text style={textStyle}>
@@ -69,6 +71,7 @@ const styles = EStyleSheet.create({
 StyledText.propTypes = {
   text: React.PropTypes.string,
   textStyle: React.PropTypes.string,
+  additionalStyles: React.PropTypes.array,
 }
 
 export default StyledText

--- a/src/components/__tests__/__snapshots__/Input-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Input-test.js.snap
@@ -7,7 +7,11 @@ exports[`test renders a label correctly 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}>
+      style={
+        Array [
+          undefined,
+        ]
+      }>
       Ermahgerd Berks
     </Text>
   </View>

--- a/src/components/__tests__/__snapshots__/PublicationFilter-test.js.snap
+++ b/src/components/__tests__/__snapshots__/PublicationFilter-test.js.snap
@@ -18,7 +18,11 @@ exports[`test does not render when not connected 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}>
+          style={
+            Array [
+              undefined,
+            ]
+          }>
           Choose Category
         </Text>
         <Text
@@ -65,7 +69,11 @@ exports[`test renders correctly 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}>
+          style={
+            Array [
+              undefined,
+            ]
+          }>
           Choose Category
         </Text>
         <Text
@@ -112,7 +120,11 @@ exports[`test renders selected discipline 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}>
+          style={
+            Array [
+              undefined,
+            ]
+          }>
           Viewing Science
         </Text>
         <Text

--- a/src/components/__tests__/__snapshots__/PublicationList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/PublicationList-test.js.snap
@@ -26,7 +26,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Choose Category
           </Text>
           <Text

--- a/src/components/__tests__/__snapshots__/Register-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Register-test.js.snap
@@ -12,7 +12,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             User Name
           </Text>
         </View>
@@ -37,7 +41,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Email address
           </Text>
         </View>
@@ -64,7 +72,11 @@ exports[`test renders correctly 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              style={undefined}>
+              style={
+                Array [
+                  undefined,
+                ]
+              }>
               Password
             </Text>
             <Text
@@ -194,7 +206,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Real name
           </Text>
           <Text
@@ -384,7 +400,11 @@ exports[`test renders errors 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             User Name
           </Text>
         </View>
@@ -409,7 +429,11 @@ exports[`test renders errors 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Email address
           </Text>
         </View>
@@ -436,7 +460,11 @@ exports[`test renders errors 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              style={undefined}>
+              style={
+                Array [
+                  undefined,
+                ]
+              }>
               Password
             </Text>
             <Text
@@ -566,7 +594,11 @@ exports[`test renders errors 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Real name
           </Text>
           <Text

--- a/src/components/__tests__/__snapshots__/SignIn-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SignIn-test.js.snap
@@ -24,7 +24,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Username or Email Address
           </Text>
         </View>
@@ -49,7 +53,11 @@ exports[`test renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Password
           </Text>
         </View>
@@ -177,7 +185,11 @@ exports[`test renders error message 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Username or Email Address
           </Text>
         </View>
@@ -202,7 +214,11 @@ exports[`test renders error message 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}>
+            style={
+              Array [
+                undefined,
+              ]
+            }>
             Password
           </Text>
         </View>

--- a/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -18,7 +18,11 @@ exports[`test renders text correctly 1`] = `
   accessible={true}
   allowFontScaling={true}
   ellipsizeMode="tail"
-  style={undefined}>
+  style={
+    Array [
+      undefined,
+    ]
+  }>
   O Hai!
 </Text>
 `;

--- a/src/containers/zooniverseApp.js
+++ b/src/containers/zooniverseApp.js
@@ -1,21 +1,54 @@
 import React, {Component} from 'react'
 import {
+  Platform,
+  PushNotificationIOS,
   View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import ProjectDisciplines from '../components/ProjectDisciplines'
+import NotificationModal from '../components/NotificationModal'
 import NavBar from '../components/NavBar'
 import { connect } from 'react-redux'
+import { setState } from '../actions/index'
+import FCM from 'react-native-fcm'
 
 const mapStateToProps = (state) => ({
   user: state.user,
   isFetching: state.isFetching,
   isConnected: state.isConnected,
+  isModalVisible: state.isModalVisible || false,
+  notificationPayload: state.notificationPayload || {}
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  setModalVisibility(value) {
+    dispatch(setState('isModalVisible', value))
+  },
+  setNotificationPayload(value) {
+    dispatch(setState('notificationPayload', value))
+  },
 })
 
 class ZooniverseApp extends Component {
   constructor(props) {
     super(props);
+  }
+
+  componentDidMount() {
+    if (Platform.OS === 'ios') {
+      PushNotificationIOS.addEventListener('notification', this.onRemoteNotification)
+    } else {
+      FCM.on('notification', this.onRemoteNotification)
+    }
+  }
+
+  componentWillUnmount() {
+    PushNotificationIOS.removeEventListener('notification', this.onRemoteNotificationIOS);
+  }
+
+  onRemoteNotification = (notification) => {
+    this.props.setNotificationPayload(notification)
+    this.props.setModalVisibility(true)
   }
 
   static renderNavigationBar() {
@@ -26,6 +59,9 @@ class ZooniverseApp extends Component {
     return (
       <View style={styles.container}>
         { this.props.isFetching ? null : <ProjectDisciplines /> }
+        <NotificationModal
+          isVisible={this.props.isModalVisible}
+          setVisibility={this.props.setModalVisibility}/>
       </View>
     )
   }
@@ -41,6 +77,9 @@ ZooniverseApp.propTypes = {
   user: React.PropTypes.object,
   isFetching: React.PropTypes.bool.isRequired,
   isConnected: React.PropTypes.bool,
+  isModalVisible: React.PropTypes.bool,
+  setModalVisibility: React.PropTypes.func,
+  setNotificationPayload: React.PropTypes.func,
 }
 
-export default connect(mapStateToProps)(ZooniverseApp)
+export default connect(mapStateToProps, mapDispatchToProps)(ZooniverseApp)

--- a/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
+++ b/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
@@ -4,6 +4,8 @@ Object {
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
+  "notificationPayload": Object {},
+  "notificationProject": Object {},
   "projectList": Array [],
   "registration": Object {
     "global_email_communication": true,
@@ -19,6 +21,8 @@ Object {
   "errorMessage": null,
   "isConnected": true,
   "isFetching": false,
+  "notificationPayload": Object {},
+  "notificationProject": Object {},
   "projectList": Array [],
   "registration": Object {
     "global_email_communication": true,
@@ -34,6 +38,8 @@ Object {
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
+  "notificationPayload": Object {},
+  "notificationProject": Object {},
   "projectList": Array [],
   "registration": Object {
     "global_email_communication": true,
@@ -52,6 +58,8 @@ Object {
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
+  "notificationPayload": Object {},
+  "notificationProject": Object {},
   "projectList": Array [],
   "registration": Object {
     "global_email_communication": true,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,8 @@ export const InitialState = {
   selectedDiscipline: null,
   projectList: [],
   webViewNavCounter: 0,
+  notificationProject: {},
+  notificationPayload: {},
 }
 
 export default function(state=InitialState, action) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -13,4 +13,5 @@ export default {
   lightGrey: 'rgba(240, 240, 240, 1)',
   grey: 'rgba(164, 164, 164, 1)',
   mediumGrey: 'rgba(216, 216, 216, 1)',
+  navy: 'rgba(12, 72, 129, 1)',
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,5 +11,6 @@ export default {
   transparent: 'rgba(0, 0, 0, 0)',
   darkTextColor: 'rgba(12, 71, 128, 1)',
   lightGrey: 'rgba(240, 240, 240, 1)',
-  grey: 'rgba(164, 164, 164, 1)'
+  grey: 'rgba(164, 164, 164, 1)',
+  mediumGrey: 'rgba(216, 216, 216, 1)',
 }


### PR DESCRIPTION
  *  Adds support to handle project_id in push notification payload
  *  Uses PushNotificationIOS from react-native for iOS and react-native-fcm for android/firebase
  *  On Android, when app is in foreground, sends a local notification to display in the system tray
  *  When project ID is present and one that is listed in the Mobile-Friendly projects) it will directly open that project in the browser

Fixes #72 