### PR TITLE
Add notifications settings screen

### DIFF
--- a/android/app/src/main/java/com/zooniversemobile/MainActivity.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainActivity.java
@@ -16,12 +16,12 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.firebase.messaging.RemoteMessage;
 import com.pusher.android.PusherAndroid;
-import com.pusher.android.notifications.PushNotificationRegistration;
 import com.pusher.android.notifications.fcm.FCMPushNotificationReceivedListener;
 import com.pusher.android.notifications.tokens.PushNotificationRegistrationListener;
 
 public class MainActivity extends ReactActivity {
     private static final int PLAY_SERVICES_RESOLUTION_REQUEST = 9000;
+    private static MainActivity mainActivity;
 
     /**
      * Returns the name of the main component registered from JavaScript.
@@ -31,6 +31,7 @@ public class MainActivity extends ReactActivity {
     protected String getMainComponentName() {
         return "ZooniverseMobile";
     }
+    public MainActivity getInstance() { return mainActivity; }
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         Intent intent = new Intent("onConfigurationChanged");
@@ -44,13 +45,13 @@ public class MainActivity extends ReactActivity {
 
         if (playServicesAvailable()) {
             PusherAndroid pusher = new PusherAndroid(BuildConfig.PUSHER_API_KEY);
-            final PushNotificationRegistration nativePusher = pusher.nativePusher();
+            PusherProperty.getInstance().nativePusher = pusher.nativePusher();
 
             try {
-                nativePusher.registerFCM(this, new PushNotificationRegistrationListener() {
+                PusherProperty.getInstance().nativePusher.registerFCM(this, new PushNotificationRegistrationListener() {
                     @Override
                     public void onSuccessfulRegistration() {
-                        nativePusher.subscribe("general");
+                        PusherProperty.getInstance().nativePusher.subscribe("general");
                     }
 
                     @Override
@@ -66,7 +67,7 @@ public class MainActivity extends ReactActivity {
                 e.printStackTrace();
             }
 
-            nativePusher.setFCMListener(new FCMPushNotificationReceivedListener() {
+            PusherProperty.getInstance().nativePusher.setFCMListener(new FCMPushNotificationReceivedListener() {
                 @Override
                 public void onMessageReceived(RemoteMessage remoteMessage) {
                 String projectID = String.valueOf(remoteMessage.getData().get("project_id"));

--- a/android/app/src/main/java/com/zooniversemobile/MainApplication.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplication.java
@@ -26,6 +26,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+          new MainApplicationPackage(),
           new GoogleAnalyticsBridgePackage(),
           new WebViewBridgePackage(),
           new RNSvgPackage(),

--- a/android/app/src/main/java/com/zooniversemobile/MainApplicationPackage.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplicationPackage.java
@@ -1,0 +1,37 @@
+package com.zooniversemobile;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by rschaaf on 11/4/16.
+ */
+public class MainApplicationPackage implements ReactPackage {
+
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new NotificationSettings(reactContext));
+
+        return modules;
+    }
+}

--- a/android/app/src/main/java/com/zooniversemobile/NotificationSettings.java
+++ b/android/app/src/main/java/com/zooniversemobile/NotificationSettings.java
@@ -1,0 +1,38 @@
+package com.zooniversemobile;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.pusher.android.notifications.PushNotificationRegistration;
+
+/**
+ * Created by rschaaf on 11/4/16.
+ */
+
+
+public class NotificationSettings extends ReactContextBaseJavaModule {
+    private PushNotificationRegistration nativePusher = null;
+
+    public NotificationSettings(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "NotificationSettings";
+    }
+
+    @ReactMethod
+    public void setInterestSubscription(String interest, Boolean subscribed, Promise promise) {
+        nativePusher = PusherProperty.getInstance().nativePusher;
+        if (subscribed) {
+            nativePusher.subscribe(interest);
+        } else {
+            nativePusher.unsubscribe(interest);
+        }
+
+        promise.resolve("Subscription update successful");
+    }
+
+}

--- a/android/app/src/main/java/com/zooniversemobile/PusherProperty.java
+++ b/android/app/src/main/java/com/zooniversemobile/PusherProperty.java
@@ -1,0 +1,21 @@
+package com.zooniversemobile;
+
+import com.pusher.android.notifications.PushNotificationRegistration;
+
+/**
+ * Created by rschaaf on 11/4/16.
+ */
+public class PusherProperty {
+    private static PusherProperty mInstance= null;
+
+    public PushNotificationRegistration nativePusher;
+
+    protected PusherProperty(){}
+
+    public static synchronized PusherProperty getInstance(){
+        if(null == mInstance){
+            mInstance = new PusherProperty();
+        }
+        return mInstance;
+    }
+}

--- a/ios/ZooniverseMobile.xcodeproj/project.pbxproj
+++ b/ios/ZooniverseMobile.xcodeproj/project.pbxproj
@@ -28,8 +28,9 @@
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		992180751D9B18E400F8BEDD /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 992180741D9B18E400F8BEDD /* FontAwesome.ttf */; };
 		992864FA1E08908900142B69 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 992864F91E08908900142B69 /* WebKit.framework */; };
-		99911C7E1E098FF5000A70D3 /* libReact-Native-Webview-Bridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99911C7B1E098FE2000A70D3 /* libReact-Native-Webview-Bridge.a */; };
+		992C27581E5394C200C4C17B /* NotificationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 992C27561E5394C200C4C17B /* NotificationSettings.m */; };
 		995543911DE362940016257B /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 995543901DE3624E0016257B /* libRNSVG.a */; };
+		99911C7E1E098FF5000A70D3 /* libReact-Native-Webview-Bridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99911C7B1E098FE2000A70D3 /* libReact-Native-Webview-Bridge.a */; };
 		999F9C831DB7B4FA002B6AF0 /* OpenSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C781DB7B4FA002B6AF0 /* OpenSans-Bold.ttf */; };
 		999F9C841DB7B4FA002B6AF0 /* OpenSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C791DB7B4FA002B6AF0 /* OpenSans-BoldItalic.ttf */; };
 		999F9C851DB7B4FA002B6AF0 /* OpenSans-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 999F9C7A1DB7B4FA002B6AF0 /* OpenSans-ExtraBold.ttf */; };
@@ -126,54 +127,12 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
-		995543721DE3624E0016257B /* PBXContainerItemProxy */ = {
+		9955438F1DE3624E0016257B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
+			containerPortal = 9955436A1DE3624E0016257B /* RNSVG.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 2D2A283A1D9B042B00D4039D;
-			remoteInfo = "RCTImage-tvOS";
-		};
-		995543761DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28471D9B043800D4039D;
-			remoteInfo = "RCTLinking-tvOS";
-		};
-		9955437A1DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28541D9B044C00D4039D;
-			remoteInfo = "RCTNetwork-tvOS";
-		};
-		9955437F1DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28611D9B046600D4039D;
-			remoteInfo = "RCTSettings-tvOS";
-		};
-		995543831DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A287B1D9B048500D4039D;
-			remoteInfo = "RCTText-tvOS";
-		};
-		995543881DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28881D9B049200D4039D;
-			remoteInfo = "RCTWebSocket-tvOS";
-		};
-		9955438C1DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28131D9B038B00D4039D;
-			remoteInfo = "React-tvOS";
+			remoteGlobalIDString = 0CF68AC11AF0540F00FF9E5C;
+			remoteInfo = RNSVG;
 		};
 		99911C7A1E098FE2000A70D3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -181,13 +140,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 4114DC4C1C187C3A003CD988;
 			remoteInfo = "React-Native-Webview-Bridge";
-		};
-		9955438F1DE3624E0016257B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9955436A1DE3624E0016257B /* RNSVG.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0CF68AC11AF0540F00FF9E5C;
-			remoteInfo = RNSVG;
 		};
 		99AC04501D7626D400E303A3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -296,8 +248,10 @@
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		992180741D9B18E400F8BEDD /* FontAwesome.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		992864F91E08908900142B69 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		99911C641E098FE2000A70D3 /* React-Native-Webview-Bridge.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "React-Native-Webview-Bridge.xcodeproj"; path = "../node_modules/react-native-webview-bridge/ios/React-Native-Webview-Bridge.xcodeproj"; sourceTree = "<group>"; };
+		992C27561E5394C200C4C17B /* NotificationSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NotificationSettings.m; path = ZooniverseMobile/NotificationSettings.m; sourceTree = "<group>"; };
+		992C27571E5394C200C4C17B /* NotificationSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NotificationSettings.h; path = ZooniverseMobile/NotificationSettings.h; sourceTree = "<group>"; };
 		9955436A1DE3624E0016257B /* RNSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
+		99911C641E098FE2000A70D3 /* React-Native-Webview-Bridge.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "React-Native-Webview-Bridge.xcodeproj"; path = "../node_modules/react-native-webview-bridge/ios/React-Native-Webview-Bridge.xcodeproj"; sourceTree = "<group>"; };
 		999F9C781DB7B4FA002B6AF0 /* OpenSans-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenSans-Bold.ttf"; sourceTree = "<group>"; };
 		999F9C791DB7B4FA002B6AF0 /* OpenSans-BoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenSans-BoldItalic.ttf"; sourceTree = "<group>"; };
 		999F9C7A1DB7B4FA002B6AF0 /* OpenSans-ExtraBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenSans-ExtraBold.ttf"; sourceTree = "<group>"; };
@@ -441,6 +395,8 @@
 		13B07FAE1A68108700A75B9A /* ZooniverseMobile */ = {
 			isa = PBXGroup;
 			children = (
+				992C27561E5394C200C4C17B /* NotificationSettings.m */,
+				992C27571E5394C200C4C17B /* NotificationSettings.h */,
 				99C686741D958DE000FF0CB2 /* ZooniverseMobile.entitlements */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -530,18 +486,18 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		99911C651E098FE2000A70D3 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				99911C7B1E098FE2000A70D3 /* libReact-Native-Webview-Bridge.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		9955436B1DE3624E0016257B /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				995543901DE3624E0016257B /* libRNSVG.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		99911C651E098FE2000A70D3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				99911C7B1E098FE2000A70D3 /* libReact-Native-Webview-Bridge.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -830,55 +786,6 @@
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		995543731DE3624E0016257B /* libRCTImage-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTImage-tvOS.a";
-			remoteRef = 995543721DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		995543771DE3624E0016257B /* libRCTLinking-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTLinking-tvOS.a";
-			remoteRef = 995543761DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		9955437B1DE3624E0016257B /* libRCTNetwork-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTNetwork-tvOS.a";
-			remoteRef = 9955437A1DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		995543801DE3624E0016257B /* libRCTSettings-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTSettings-tvOS.a";
-			remoteRef = 9955437F1DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		995543841DE3624E0016257B /* libRCTText-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTText-tvOS.a";
-			remoteRef = 995543831DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		995543891DE3624E0016257B /* libRCTWebSocket-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTWebSocket-tvOS.a";
-			remoteRef = 995543881DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		9955438D1DE3624E0016257B /* libReact-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libReact-tvOS.a";
-			remoteRef = 9955438C1DE3624E0016257B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		995543901DE3624E0016257B /* libRNSVG.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1093,6 +1000,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				992C27581E5394C200C4C17B /* NotificationSettings.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/ZooniverseMobile/NotificationSettings.h
+++ b/ios/ZooniverseMobile/NotificationSettings.h
@@ -1,0 +1,17 @@
+//
+//  NotificationSettings.h
+//  ZooniverseMobile
+//
+//  Created by Robin Schaaf on 11/3/16.
+//  Copyright © 2016 Zooniverse. All rights reserved.
+//
+
+#import "RCTBridgeModule.h"
+#import "AppDelegate.h"
+#import <Pusher/Pusher.h>
+
+@interface NotificationSettings : NSObject <RCTBridgeModule, PTPusherDelegate>
+
+@property (nonatomic, strong) PTPusher *pusher;
+
+@end

--- a/ios/ZooniverseMobile/NotificationSettings.m
+++ b/ios/ZooniverseMobile/NotificationSettings.m
@@ -1,0 +1,36 @@
+//
+//  NotificationSettings.m
+//  ZooniverseMobile
+//
+//  Created by Robin Schaaf on 11/3/16.
+//  Copyright © 2016 Zooniverse. All rights reserved.
+//
+
+#import "NotificationSettings.h"
+#import "RCTLog.h"
+#import <Pusher/Pusher.h>
+
+@implementation NotificationSettings
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(setInterestSubscription:(NSString *)interest
+                  subscribed:(BOOL *)subscribed
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  
+  AppDelegate *appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
+  self.pusher = appDelegate.pusher;
+  
+  if (subscribed) {
+    [[[self pusher] nativePusher] subscribe:interest];
+  } else {
+    [[[self pusher] nativePusher] unsubscribe:interest];
+  }
+  
+  resolve(@"Interest subscription set");
+}
+
+
+@end

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -2,7 +2,7 @@ import auth from 'panoptes-client/lib/auth'
 import store from 'react-native-simple-store'
 import { Actions, ActionConst } from 'react-native-router-flux'
 
-import { checkIsConnected, setState, setIsFetching } from '../actions/index'
+import { checkIsConnected, loadNotificationSettings, setState, setIsFetching } from '../actions/index'
 import { loadUserAvatar, loadUserProjects, syncUserStore } from '../actions/user'
 
 export function getAuthUser() {
@@ -29,7 +29,8 @@ export function signIn(login, password) {
 
         return Promise.all([
           dispatch(loadUserAvatar()),
-          dispatch(loadUserProjects())
+          dispatch(loadUserProjects()),
+          dispatch(loadNotificationSettings())
         ])
       }).then(() => {
         dispatch(syncUserStore())
@@ -88,8 +89,10 @@ export function signOut() {
 
 export function continueAsGuest() {
   return dispatch => {
-    dispatch(setState('user.isGuestUser', true))
-    dispatch(syncUserStore())
+    dispatch(loadNotificationSettings()).then(() => {
+      dispatch(setState('user.isGuestUser', true))
+      dispatch(syncUserStore())
+    })
     Actions.ZooniverseApp({type: ActionConst.RESET})
   }
 }

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -4,7 +4,7 @@ import store from 'react-native-simple-store'
 import { Actions } from 'react-native-router-flux'
 import { add, addIndex, filter, head, keys, map, reduce } from 'ramda'
 
-import { fetchProjectsByParms, setState } from '../actions/index'
+import { fetchProjectsByParms, loadNotificationSettings, setState } from '../actions/index'
 import { getAuthUser } from '../actions/auth'
 
 export function syncUserStore() {
@@ -33,11 +33,14 @@ export function loadUserData() {
   return (dispatch, getState) => {
     dispatch(setUserFromStore()).then(() => {
       if (getState().user.isGuestUser) {
-        return
+        return Promise.all([
+          dispatch(loadNotificationSettings())
+        ])
       } else {
         return Promise.all([
           dispatch(loadUserAvatar()),
-          dispatch(loadUserProjects())
+          dispatch(loadUserProjects()),
+          dispatch(loadNotificationSettings()),
         ])
       }
     }).then(() => {

--- a/src/components/NotificationSettings.js
+++ b/src/components/NotificationSettings.js
@@ -51,12 +51,12 @@ export class NotificationSettings extends React.Component {
 
 
   render() {
-    var mobileProjects = flatten(
+    let mobileProjects = flatten(
       map((tag) => { return this.props.projectList[tag] }, keys(this.props.projectList))
     )
 
     const renderPreference = (id, idx) => {
-      var project = find(propEq('id', id))(mobileProjects)
+      let project = find(propEq('id', id))(mobileProjects)
 
       if (project === undefined) { //project may no longer exist
         return
@@ -87,7 +87,7 @@ export class NotificationSettings extends React.Component {
         <View style={styles.switchContainer}>
           <Switch
             value={this.props.notifications['general']}
-            style={styles.switch}
+            style={styles.switchComponent}
             onTintColor={theme.headerColor}
             onValueChange={(checked) => this.props.updateGeneralNotification(checked)}
           />
@@ -134,7 +134,7 @@ const styles = EStyleSheet.create({
     borderBottomColor: '$lightGrey',
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  switch: {
+  switchComponent: {
     marginRight: 10,
   },
 });

--- a/src/components/NotificationSettings.js
+++ b/src/components/NotificationSettings.js
@@ -1,0 +1,153 @@
+import React from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  Switch,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import theme from '../theme'
+import StyledText from './StyledText'
+import NavBar from './NavBar'
+import OverlaySpinner from './OverlaySpinner'
+import ProjectNotification from './ProjectNotification'
+import { connect } from 'react-redux'
+import { checkPushPermissions, setState, updateInterestSubscription, syncNotificationStore } from '../actions/index'
+import { addIndex, find, keys, map, flatten, propEq, without } from 'ramda'
+import GoogleAnalytics from 'react-native-google-analytics-bridge'
+
+GoogleAnalytics.trackEvent('view', 'Notification Settings')
+
+const mapStateToProps = (state) => ({
+  notifications: state.notifications,
+  projectList: state.projectList,
+  isFetching: state.isFetching,
+  errorMessage: state.errorMessage,
+  pushEnabled: state.pushEnabled
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  updateGeneralNotification(checked) {
+    dispatch(setState('notifications.general', checked))
+    dispatch(syncNotificationStore())
+    dispatch(updateInterestSubscription('general', checked))
+  },
+  setState(key, value){
+    dispatch(setState(key, value))
+  },
+  checkPushPermissions(){
+    dispatch(checkPushPermissions())
+  }
+})
+
+export class NotificationSettings extends React.Component {
+  componentDidMount() {
+    this.props.checkPushPermissions()
+  }
+
+  static renderNavigationBar() {
+    return <NavBar title={'Notification Settings'} showBack={true} />;
+  }
+
+
+  render() {
+    var mobileProjects = flatten(
+      map((tag) => { return this.props.projectList[tag] }, keys(this.props.projectList))
+    )
+
+    const renderPreference = (id, idx) => {
+      var project = find(propEq('id', id))(mobileProjects)
+
+      if (project === undefined) { //project may no longer exist
+        return
+      } else {
+        return (
+          <ProjectNotification
+            id={id}
+            name={project.display_name}
+            key={idx} /> )
+      }
+    }
+
+    const projectNotificationsList =
+      <View>
+        <StyledText textStyle={'subHeaderText'}
+          text={'Project-specific Notifications'} />
+
+        {addIndex(map)(
+            (key, idx) => { return renderPreference(key, idx) },
+            without(['general'] , keys(this.props.notifications))
+        )}
+      </View>
+
+    const preferencesScrollView =
+      <ScrollView>
+        <StyledText
+          text={'Zooniverse would like to occassionally send you updates about new projects or projects needing help.'} />
+        <View style={styles.switchContainer}>
+          <Switch
+            value={this.props.notifications['general']}
+            style={styles.switch}
+            onTintColor={theme.headerColor}
+            onValueChange={(checked) => this.props.updateGeneralNotification(checked)}
+          />
+          <StyledText text="General Zooniverse notifications" />
+        </View>
+
+        { this.props.notifications ? projectNotificationsList : null }
+      </ScrollView>
+
+    const noNotifications =
+      <View>
+        <StyledText
+          text={'Push notifications are not enabled on your device!  Please go to Settings > Notifications > Zooniverse to allow them.'} />
+      </View>
+
+    const pageView =
+      this.props.pushEnabled ? preferencesScrollView : noNotifications
+
+    return (
+      <View style={styles.container}>
+        <StyledText textStyle={'errorMessage'} text={this.props.errorMessage} />
+        { this.props.isFetching ? <OverlaySpinner /> : pageView }
+      </View>
+    );
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 60,
+    paddingLeft: 10,
+    paddingRight: 10
+  },
+  messageContainer: {
+    padding: 15,
+  },
+  switchContainer: {
+    flexDirection: 'row',
+    paddingLeft: 8,
+    paddingBottom: 16,
+    paddingTop: 16,
+    alignItems: 'center',
+    borderBottomColor: '$lightGrey',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  switch: {
+    marginRight: 10,
+  },
+});
+
+NotificationSettings.propTypes = {
+  notifications: React.PropTypes.object,
+  projectList: React.PropTypes.object,
+  isFetching: React.PropTypes.bool,
+  pushEnabled: React.PropTypes.bool,
+  errorMessage: React.PropTypes.string,
+  setState: React.PropTypes.func,
+  updateGeneralNotification: React.PropTypes.func,
+  checkPushPermissions: React.PropTypes.func,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotificationSettings)

--- a/src/components/ProjectNotification.js
+++ b/src/components/ProjectNotification.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import {
+  Switch,
+  View
+} from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet'
+import theme from '../theme'
+import StyledText from './StyledText'
+import { connect } from 'react-redux'
+import { setState, syncNotificationStore, updateInterestSubscription } from '../actions/index'
+
+const mapStateToProps = (state, ownProps) => ({
+  notification: state.notifications[ownProps.id]
+})
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  updateProjectNotification(checked) {
+    dispatch(setState(`notifications.${ownProps.id}`, checked))
+    dispatch(syncNotificationStore())
+    dispatch(updateInterestSubscription(ownProps.id, checked))
+  },
+})
+
+export class ProjectNotification extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Switch
+          value={this.props.notification}
+          style={styles.switch}
+          onTintColor={theme.headerColor}
+          onValueChange={(checked) => this.props.updateProjectNotification(checked)}
+        />
+
+        <StyledText text={this.props.name} />
+      </View>
+    );
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    padding: 8,
+    alignItems: 'center'
+  },
+  switch: {
+    marginRight: 10
+  },
+});
+
+ProjectNotification.propTypes = {
+  id: React.PropTypes.string.isRequired,
+  name: React.PropTypes.string.isRequired,
+  notification: React.PropTypes.bool.isRequired,
+  updateProjectNotification: React.PropTypes.func.isRequired,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProjectNotification)

--- a/src/components/ProjectNotification.js
+++ b/src/components/ProjectNotification.js
@@ -27,7 +27,7 @@ export class ProjectNotification extends Component {
       <View style={styles.container}>
         <Switch
           value={this.props.notification}
-          style={styles.switch}
+          style={styles.switchComponent}
           onTintColor={theme.headerColor}
           onValueChange={(checked) => this.props.updateProjectNotification(checked)}
         />
@@ -44,7 +44,7 @@ const styles = EStyleSheet.create({
     padding: 8,
     alignItems: 'center'
   },
-  switch: {
+  switchComponent: {
     marginRight: 10
   },
 });

--- a/src/components/SideDrawerContent.js
+++ b/src/components/SideDrawerContent.js
@@ -32,6 +32,7 @@ export class SideDrawerContent extends Component {
     this.signOut = this.signOut.bind(this)
     this.goToAbout = this.goToAbout.bind(this)
     this.goToPublications = this.goToPublications.bind(this)
+    this.notificationSettings = this.notificationSettings.bind(this)
     this.signIn = this.signIn.bind(this)
   }
 
@@ -63,6 +64,11 @@ export class SideDrawerContent extends Component {
   goToPublications(){
     this.close()
     Actions.Publications()
+  }
+
+  notificationSettings(){
+    this.close()
+    Actions.NotificationSettings()
   }
 
   openSocialMediaLink(link) {
@@ -121,6 +127,12 @@ export class SideDrawerContent extends Component {
           <StyledText
             textStyle={'largeLink'}
             text={'Publications'} />
+        </TouchableOpacity>
+        
+        <TouchableOpacity onPress={this.notificationSettings} style={styles.linkContainer}>
+          <StyledText
+            textStyle={'largeLink'}
+            text={'Notification Settings'} />
         </TouchableOpacity>
 
         { this.props.isGuestUser ? null : signOut }

--- a/src/components/__tests__/NotificationSettings-test.js
+++ b/src/components/__tests__/NotificationSettings-test.js
@@ -1,0 +1,24 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { NotificationSettings } from '../NotificationSettings'
+
+jest.mock('Switch', () => 'Switch');
+
+const notifications = {
+  'general': true
+}
+
+it('renders', () => {
+  const tree = renderer.create(
+    <NotificationSettings notifications={notifications} checkPushPermissions={jest.fn} pushEnabled={true} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders message if push is disabled', () => {
+  const tree = renderer.create(
+    <NotificationSettings notifications={{}} checkPushPermissions={jest.fn} pushEnabled={false} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/ProjectNotification-test.js
+++ b/src/components/__tests__/ProjectNotification-test.js
@@ -1,0 +1,20 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ProjectNotification } from '../ProjectNotification'
+
+jest.mock('Switch', () => 'Switch');
+
+it('renders checked', () => {
+  const tree = renderer.create(
+    <ProjectNotification id={'1'} name={'test'} notification={true} updateProjectNotification={jest.fn} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders not checked', () => {
+  const tree = renderer.create(
+    <ProjectNotification id={'1'} name={'test'} notification={false} updateProjectNotification={jest.fn} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/NotificationSettings-test.js.snap
+++ b/src/components/__tests__/__snapshots__/NotificationSettings-test.js.snap
@@ -1,0 +1,90 @@
+exports[`test renders 1`] = `
+<View
+  style={undefined}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    } />
+  <ScrollView>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+        ]
+      }>
+      Zooniverse would like to occassionally send you updates about new projects or projects needing help.
+    </Text>
+    <View
+      style={undefined}>
+      <Switch
+        onTintColor="rgba(0, 151, 157, 1)"
+        onValueChange={[Function]}
+        style={undefined}
+        value={true} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+          ]
+        }>
+        General Zooniverse notifications
+      </Text>
+    </View>
+    <View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }>
+        Project-specific Notifications
+      </Text>
+    </View>
+  </ScrollView>
+</View>
+`;
+
+exports[`test renders message if push is disabled 1`] = `
+<View
+  style={undefined}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    } />
+  <View>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+        ]
+      }>
+      Push notifications are not enabled on your device!  Please go to Settings > Notifications > Zooniverse to allow them.
+    </Text>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/ProjectNotification-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProjectNotification-test.js.snap
@@ -1,0 +1,43 @@
+exports[`test renders checked 1`] = `
+<View
+  style={undefined}>
+  <Switch
+    onTintColor="rgba(0, 151, 157, 1)"
+    onValueChange={[Function]}
+    style={undefined}
+    value={true} />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        undefined,
+      ]
+    }>
+    test
+  </Text>
+</View>
+`;
+
+exports[`test renders not checked 1`] = `
+<View
+  style={undefined}>
+  <Switch
+    onTintColor="rgba(0, 151, 157, 1)"
+    onValueChange={[Function]}
+    style={undefined}
+    value={false} />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        undefined,
+      ]
+    }>
+    test
+  </Text>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/SideDrawerContent-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SideDrawerContent-test.js.snap
@@ -89,6 +89,23 @@ exports[`test renders correctly 1`] = `
           undefined,
         ]
       }>
+      Notification Settings
+    </Text>
+  </TouchableOpacity>
+  <TouchableOpacity
+    activeOpacity={0.2}
+    onPress={[Function]}
+    style={undefined}>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          undefined,
+        ]
+      }>
       Sign Out
     </Text>
   </TouchableOpacity>

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -15,6 +15,7 @@ import About from '../components/About'
 import PublicationList from '../components/PublicationList'
 import SignIn from '../components/SignIn'
 import Register from '../components/Register'
+import NotificationSettings from '../components/NotificationSettings'
 import SideDrawer from '../components/SideDrawer'
 import ZooWebView from '../components/ZooWebView'
 import Onboarding from '../components/Onboarding'
@@ -54,6 +55,7 @@ export default class App extends Component {
               <Scene key="Publications" component={PublicationList} />
               <Scene key="ProjectList" component={ProjectList} />
               <Scene key="Register" component={Register} />
+              <Scene key="NotificationSettings" component={NotificationSettings} />
               <Scene key="ZooWebView" hideNavBar={true} component={ZooWebView} duration={0} />
               <Scene key="Onboarding" component={Onboarding} duration={0} hideNavBar={true} sceneConfig={Navigator.SceneConfigs.FloatFromLeft} />
             </Scene>

--- a/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
+++ b/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
@@ -6,7 +6,11 @@ Object {
   "isFetching": false,
   "notificationPayload": Object {},
   "notificationProject": Object {},
+  "notifications": Object {
+    "general": true,
+  },
   "projectList": Array [],
+  "pushEnabled": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -23,7 +27,11 @@ Object {
   "isFetching": false,
   "notificationPayload": Object {},
   "notificationProject": Object {},
+  "notifications": Object {
+    "general": true,
+  },
   "projectList": Array [],
+  "pushEnabled": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -40,7 +48,11 @@ Object {
   "isFetching": false,
   "notificationPayload": Object {},
   "notificationProject": Object {},
+  "notifications": Object {
+    "general": true,
+  },
   "projectList": Array [],
+  "pushEnabled": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -60,7 +72,11 @@ Object {
   "isFetching": false,
   "notificationPayload": Object {},
   "notificationProject": Object {},
+  "notifications": Object {
+    "general": true,
+  },
   "projectList": Array [],
+  "pushEnabled": false,
   "registration": Object {
     "global_email_communication": true,
   },

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,6 +11,8 @@ export const InitialState = {
   webViewNavCounter: 0,
   notificationProject: {},
   notificationPayload: {},
+  notifications: { general: true },
+  pushEnabled: false,
 }
 
 export default function(state=InitialState, action) {


### PR DESCRIPTION
Adds the Notification Settings screen (on the side menu) to allow users to subscribe or unsubscribe to General Zooniverse Notifications or specific projects (populated from the list of Mobile-Friendly Projects).
Note that the notification settings are saved at the device level, since the list of projects are based on the Mobile friendly projects (and not the user preferences), and also notifications subscriptions are stored at the device level with Pusher.

  *  Add support in android and ios for updating interest subscriptions in pusher (pusher doesn't have a react-native library, only native libraries)
  *  Use NativeModules (RN) to send message from RN to Native to update the Pusher "interest" subscriptions when checked/unchecked
  *  For iOS, if push isn't enabled, display a message explaining how to enable them
  *  Load notification settings upon signing in, or refresh
  *  Store notification settings in local storage, separate from user
  *  Add/Update tests

This can be tested using the send-push.js script, changing the to_notify to the project ID you wish to test.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

