### PR TITLE
Update Android App Display Name

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <application
       android:name=".MainApplication"
       android:allowBackup="true"
-      android:label="@string/app_name"
+      android:label="Zooniverse"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
       <activity


### PR DESCRIPTION
Currently Android is showing "ZooniverseMobile" (the project name) as the app name to the user.  This updates that label so it simply says  "Zooniverse".

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

