### PR TITLE
Add Permissions Primer

### DIFF
--- a/ios/ZooniverseMobile/AppDelegate.m
+++ b/ios/ZooniverseMobile/AppDelegate.m
@@ -30,17 +30,7 @@
 
   NSString *pusherKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"PUSHER_API_KEY"];
   self.pusher = [PTPusher pusherWithKey:pusherKey delegate:self encrypted:YES];
-  if( SYSTEM_VERSION_LESS_THAN( @"10.0" ) )
-  {
-    UIUserNotificationType notificationTypes = UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound;
-    UIUserNotificationSettings *pushNotificationSettings = [UIUserNotificationSettings settingsForTypes:notificationTypes categories: NULL];
-    [application registerUserNotificationSettings:pushNotificationSettings];
-    [application registerForRemoteNotifications];
-  }
-  else
-  {
-    [self registerForRemoteNotifications];
-  }
+  
 
   [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:@"a64221f0d73b46829478d405c90e6638"];
   // Do some additional configuration if needed here
@@ -78,21 +68,15 @@
   return [Orientation getOrientation];
 }
 
-- (void)registerForRemoteNotifications {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    center.delegate = self;
-    [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error){
-      if(!error){
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-      }
-    }];
-
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+  [RCTPushNotificationManager didRegisterUserNotificationSettings:notificationSettings];
 }
-
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
   [[[self pusher] nativePusher] registerWithDeviceToken:deviceToken];
   [[[self pusher] nativePusher] subscribe:@"general"];
+  [RCTPushNotificationManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
 

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -67,7 +67,7 @@ export class ProjectDisciplines extends React.Component {
           'Zooniverse would like to occasionally send you info about new projects or projects needing help.',
           [
             {text: 'Not Now', onPress: () => this.requestIOSPermissions(false)},
-            {text: 'Sure!', onPress: () => this.requestIOSPermissions(true)},
+            {text: 'OK', onPress: () => this.requestIOSPermissions(true)},
           ]
         )
       }

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import {
+  AlertIOS,
   Platform,
+  PushNotificationIOS,
   ScrollView,
   StyleSheet,
   View
@@ -15,6 +17,7 @@ import Discipline from './Discipline'
 import OverlaySpinner from './OverlaySpinner'
 import NavBar from '../components/NavBar'
 import { setState } from '../actions/index'
+import { syncUserStore } from '../actions/user'
 
 GoogleAnalytics.setTrackerId(GLOBALS.GOOGLE_ANALYTICS_TRACKING)
 GoogleAnalytics.trackEvent('view', 'Home')
@@ -25,18 +28,57 @@ const mapStateToProps = (state) => ({
   user: state.user,
   isGuestUser: state.user.isGuestUser,
   isConnected: state.isConnected,
-  isFetching: state.isFetching
+  isFetching: state.isFetching,
+  pushPrompted: state.user.pushPrompted
 })
 
 const mapDispatchToProps = (dispatch) => ({
   setSelectedProjectTag(tag) {
     dispatch(setState('selectedProjectTag', tag))
   },
+  setPushPrompted(value) {
+    dispatch(setState('user.pushPrompted', value))
+    dispatch(syncUserStore())
+  },
 })
 
 export class ProjectDisciplines extends React.Component {
   constructor(props) {
     super(props);
+  }
+
+  componentDidMount() {
+    if (this.shouldPromptForPermissions()) {
+      setTimeout(()=> {
+        this.promptRequestPermissions()
+      }, 500)
+    }
+  }
+
+  shouldPromptForPermissions() {
+    return ((Platform.OS === 'ios') && (!this.props.user.pushPrompted))
+  }
+
+  promptRequestPermissions = () => {
+    PushNotificationIOS.checkPermissions((permissions) => {
+      if (permissions.alert === 0){
+        AlertIOS.alert(
+          'Allow Notifications?',
+          'Zooniverse would like to occasionally send you info about new projects or projects needing help.',
+          [
+            {text: 'Not Now', onPress: () => this.requestIOSPermissions(false)},
+            {text: 'Sure!', onPress: () => this.requestIOSPermissions(true)},
+          ]
+        )
+      }
+    })
+  }
+
+  requestIOSPermissions(accepted) {
+    if (accepted) {
+      PushNotificationIOS.requestPermissions()
+    }
+    this.props.setPushPrompted(true)
   }
 
   static renderNavigationBar() {
@@ -141,7 +183,9 @@ ProjectDisciplines.propTypes = {
   isGuestUser: React.PropTypes.bool,
   isConnected: React.PropTypes.bool,
   isFetching: React.PropTypes.bool,
+  pushPrompted: React.PropTypes.bool,
   setSelectedProjectTag: React.PropTypes.func,
+  setPushPrompted: React.PropTypes.func,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectDisciplines)

--- a/src/containers/zooniverseApp.js
+++ b/src/containers/zooniverseApp.js
@@ -11,6 +11,7 @@ import LaunchScreen from '../components/Launch'
 import NavBar from '../components/NavBar'
 import { connect } from 'react-redux'
 import { setState } from '../actions/index'
+import { isEmpty } from 'ramda'
 import FCM from 'react-native-fcm'
 
 const mapStateToProps = (state) => ({
@@ -59,7 +60,7 @@ class ZooniverseApp extends Component {
   render() {
     return (
       <View style={styles.container}>
-        { this.props.isFetching ? <LaunchScreen /> : <ProjectDisciplines /> }
+        { isEmpty(this.props.user) ? <LaunchScreen /> : <ProjectDisciplines /> }
         <NotificationModal
           isVisible={this.props.isModalVisible}
           setVisibility={this.props.setModalVisibility}/>

--- a/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
+++ b/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
@@ -11,6 +11,7 @@ Object {
   },
   "projectList": Array [],
   "pushEnabled": false,
+  "pushPrompted": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -32,6 +33,7 @@ Object {
   },
   "projectList": Array [],
   "pushEnabled": false,
+  "pushPrompted": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -53,6 +55,7 @@ Object {
   },
   "projectList": Array [],
   "pushEnabled": false,
+  "pushPrompted": false,
   "registration": Object {
     "global_email_communication": true,
   },
@@ -77,6 +80,7 @@ Object {
   },
   "projectList": Array [],
   "pushEnabled": false,
+  "pushPrompted": false,
   "registration": Object {
     "global_email_communication": true,
   },

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,6 +13,7 @@ export const InitialState = {
   notificationPayload: {},
   notifications: { general: true },
   pushEnabled: false,
+  pushPrompted: false,
 }
 
 export default function(state=InitialState, action) {


### PR DESCRIPTION
Since once iOS prompts users for push notifications only once, and by default on application load, it can be a better experience and less jarring to move the permissions until later, and also to explain what notifications will be used for before prompting.
This PR:
  *  Moves to use RN's PushNotificationIOS so that the timing of the prompt is controlled on the react-native side
  *  Also uses RN alert to give the explanation and store within redux whether the user has been prompted, so it doesn't re-prompt.  (As it works currently we can't re-ask a user to enable notifications - but this way we can if they decide later they would like to enable them)

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

