### PR TITLE
Changes to offline handling

### DIFF
--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -115,12 +115,6 @@ export class ProjectDisciplines extends React.Component {
         )}
       </ScrollView>
 
-    const noConnection =
-      <View style={styles.messageContainer}>
-        <StyledText textStyle={'errorMessage'}
-          text={'You must have an internet connection to use Zooniverse Mobile'} />
-      </View>
-
     const pluralizeClassification = ( totalClassifications > 1 ? 's' : '' )
     const totalClassificationsDisiplay =
       <StyledText
@@ -135,7 +129,7 @@ export class ProjectDisciplines extends React.Component {
             { totalClassifications > 0 ? totalClassificationsDisiplay : null }
         </View>
         <View style={styles.innerContainer}>
-          { this.props.isConnected ? DisciplineList : noConnection }
+          { DisciplineList }
         </View>
         { this.props.isFetching ? <OverlaySpinner /> : null }
       </View>
@@ -181,7 +175,6 @@ const styles = EStyleSheet.create({
 ProjectDisciplines.propTypes = {
   user: React.PropTypes.object,
   isGuestUser: React.PropTypes.bool,
-  isConnected: React.PropTypes.bool,
   isFetching: React.PropTypes.bool,
   pushPrompted: React.PropTypes.bool,
   setSelectedProjectTag: React.PropTypes.func,

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -13,9 +13,8 @@ import GoogleAnalytics from 'react-native-google-analytics-bridge'
 GoogleAnalytics.trackEvent('view', 'Project')
 
 const mapStateToProps = (state) => ({
-  user: state.user,
-  projects: state.projectList[state.selectedProjectTag] || [],
-  dataSource: dataSource.cloneWithRows(state.projectList[state.selectedProjectTag])
+  projectList: state.projectList || {},
+  selectedProjectTag: state.selectedProjectTag || ''
 })
 
 const dataSource = new ListView.DataSource({
@@ -23,10 +22,6 @@ const dataSource = new ListView.DataSource({
 })
 
 export class ProjectList extends React.Component {
-  constructor(props) {
-    super(props)
-  }
-
   renderRow(project, color) {
     return (
       <Project project={project} color={color} />
@@ -38,9 +33,11 @@ export class ProjectList extends React.Component {
   }
 
   render() {
+    const projects = this.props.projectList[this.props.selectedProjectTag] || []
+
     const projectList =
       <ListView
-        dataSource={this.props.dataSource}
+        dataSource={dataSource.cloneWithRows(projects)}
         renderRow={(rowData) => this.renderRow(rowData, this.props.color)}
         enableEmptySections={true}
       />
@@ -53,7 +50,7 @@ export class ProjectList extends React.Component {
     return (
       <View style={styles.container}>
         <View style={styles.innerContainer}>
-          { this.props.projects.length > 0 ? projectList : emptyList }
+          { projects.length > 0 ? projectList : emptyList }
         </View>
       </View>
     );
@@ -70,9 +67,6 @@ const styles = EStyleSheet.create({
     flex: 1,
     marginTop: 30
   },
-  listStyle: {
-    paddingTop: 90
-  },
   emptyList: {
     marginHorizontal: 20,
     color: 'grey',
@@ -82,10 +76,8 @@ const styles = EStyleSheet.create({
 });
 
 ProjectList.propTypes = {
-  user: React.PropTypes.object,
-  dataSource: React.PropTypes.object,
-  projects: React.PropTypes.array,
-  tag: React.PropTypes.string,
+  projectList: React.PropTypes.object,
+  selectedProjectTag: React.PropTypes.string,
   color: React.PropTypes.string,
 }
 

--- a/src/components/PublicationList.js
+++ b/src/components/PublicationList.js
@@ -19,7 +19,6 @@ GoogleAnalytics.trackEvent('view', 'Publication List')
 
 const mapStateToProps = (state) => ({
   user: state.user,
-  isConnected: state.isConnected,
   disciplines: keys(state.publications),
   publications: state.publications,
   selectedDiscipline: state.selectedDiscipline,
@@ -109,15 +108,9 @@ export class PublicationList extends React.Component {
         ) }
       </ScrollView>
 
-    const noConnection =
-      <View style={styles.messageContainer}>
-        <StyledText textStyle={'errorMessage'}
-          text={'You must have an internet connection to use Zooniverse Mobile'} />
-      </View>
-
     return (
       <View style={styles.container}>
-        { this.props.isConnected ? scrollContainer : noConnection }
+        { scrollContainer }
         <PublicationFilter
           selectDiscipline = {this.props.selectedDiscipline}
           disciplines = {this.props.disciplines}
@@ -159,9 +152,6 @@ const styles = EStyleSheet.create({
 });
 
 PublicationList.propTypes = {
-  user: React.PropTypes.object,
-  isConnected: React.PropTypes.bool,
-  dataSource: React.PropTypes.object,
   disciplines: React.PropTypes.array,
   selectedDiscipline: React.PropTypes.string,
   publications: React.PropTypes.object,

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -23,7 +23,6 @@ const topPadding = (Platform.OS === 'ios') ? 72 : 60
 const mapStateToProps = (state) => ({
   isFetching: state.isFetching,
   errorMessage: state.errorMessage,
-  isConnected: state.isConnected,
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/UserAvatar.js
+++ b/src/components/UserAvatar.js
@@ -7,15 +7,17 @@ import EStyleSheet from 'react-native-extended-stylesheet'
 
 class UserAvatar extends Component {
   render() {
-
     const guestUserLogo =
       <Image source={require('../../images/simple-avatar.png')} style={styles.avatar} />
 
-    const avatar = ( <Image style={styles.avatar} source={
-        this.props.avatar
-        ? {uri: this.props.avatar}
-        : require('../../images/simple-avatar.png') } /> )
-
+    const avatar = (
+      <Image
+        defaultSource={require('../../images/simple-avatar.png')}
+        style={styles.avatar}
+        source={
+          this.props.avatar
+          ? {uri: this.props.avatar}
+          : require('../../images/simple-avatar.png') } /> )
 
     return (
       this.props.isGuestUser ? guestUserLogo : avatar

--- a/src/components/__tests__/ProjectDiscipline-test.js
+++ b/src/components/__tests__/ProjectDiscipline-test.js
@@ -3,18 +3,10 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { ProjectDisciplines } from '../ProjectDisciplines'
 
-it('renders correctly when connected', () => {
+it('renders correctly', () => {
   const user ={ display_name: 'Fake User' }
   const tree = renderer.create(
-    <ProjectDisciplines user={user} isConnected={true} />
-  ).toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-it('does not render when not connected', () => {
-  const user ={ display_name: 'Fake User' }
-  const tree = renderer.create(
-    <ProjectDisciplines user={user} isConnected={false} />
+    <ProjectDisciplines user={user} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/__tests__/ProjectList-test.js
+++ b/src/components/__tests__/ProjectList-test.js
@@ -9,6 +9,9 @@ const project = {
   display_name: 'Nice project'
 }
 
+const selectedProjectTag = 'nature'
+const projectList = { nature: [project] }
+
 jest.mock('ListView', () => require('react').createClass({
     statics: {
         DataSource: require.requireActual('ListView').DataSource,
@@ -20,7 +23,7 @@ jest.mock('ListView', () => require('react').createClass({
 
 it('renders correctly', () => {
   const tree = renderer.create(
-    <ProjectList projects={[project]} />
+    <ProjectList projectList={projectList} selectedProjectTag={selectedProjectTag} />
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/__tests__/__snapshots__/ProjectDiscipline-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProjectDiscipline-test.js.snap
@@ -1,45 +1,4 @@
-exports[`test does not render when not connected 1`] = `
-<View
-  style={undefined}>
-  <View
-    style={undefined}>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          Array [
-            undefined,
-          ],
-        ]
-      }>
-      Fake User
-    </Text>
-  </View>
-  <View
-    style={undefined}>
-    <View
-      style={undefined}>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            undefined,
-            undefined,
-          ]
-        }>
-        You must have an internet connection to use Zooniverse Mobile
-      </Text>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`test renders correctly when connected 1`] = `
+exports[`test renders correctly 1`] = `
 <View
   style={undefined}>
   <View

--- a/src/components/__tests__/__snapshots__/UserAvatar-test.js.snap
+++ b/src/components/__tests__/__snapshots__/UserAvatar-test.js.snap
@@ -1,5 +1,6 @@
 exports[`test renders correctly 1`] = `
 <Image
+  defaultSource={1}
   source={
     Object {
       "uri": "avatar",

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import reducer from '../reducers/index'
 import thunkMiddleware from 'redux-thunk'
 import {Scene, Router} from 'react-native-router-flux'
-import { setIsConnected, fetchProjects } from '../actions/index'
+import { setIsConnected, fetchProjects, setState } from '../actions/index'
 import { loadUserData } from '../actions/user'
 
 import ZooniverseApp from './zooniverseApp'
@@ -35,9 +35,10 @@ export default class App extends Component {
 
     const dispatchConnected = isConnected => store.dispatch(setIsConnected(isConnected))
     NetInfo.isConnected.fetch().then(isConnected => {
-      store.dispatch(setIsConnected(isConnected))
+      store.dispatch(setState('isConnected', isConnected))
       NetInfo.isConnected.addEventListener('change', dispatchConnected)
     })
+
 
     store.dispatch(fetchProjects())
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -32,10 +32,6 @@ export default function(state=InitialState, action) {
       return merge(state, {
         errorMessage: action.errorMessage
       })
-    case 'SET_IS_CONNECTED':
-      return merge(state, {
-        isConnected: action.isConnected
-      })
     case 'SET_PROJECT_LIST':
       return merge(state, {
         projectList: action.projectList


### PR DESCRIPTION
Fixes #42 

Describe your changes.
  *  Remove the in-component Offline messaging to instead just display an error message when the user goes offline (this seems more consistent with how other apps handle offline messaging - such as CNN, Target, etc. and also simplifies component code)
  *  Store project list in local storage to fall back on in case of slow or no internet connection, rather than making it vanish altogether
  *  Default the avatar image source in case the user is offline and we can't download the avatar image from the server
  *  Update tests

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

