### PR TITLE
Add babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
+    "babel-eslint": "^7.1.1",
     "babel-jest": "^17.0.2",
     "babel-preset-react-native": "^1.9.0",
     "eslint": "^3.4.0",

--- a/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
+++ b/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
@@ -3,6 +3,12 @@ exports[`test renders for isFetching 1`] = `
   style={undefined}>
   <Modal
     onRequestClose={[Function]}
+    supportedOrientations={
+      Array [
+        "landscape",
+        "portrait",
+      ]
+    }
     transparent={true}
     visible={true}>
     <View


### PR DESCRIPTION
Describe your changes.
Add babel-eslint to dev dependencies, the atom linter is broken without it.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

