### PR TITLE
Add crypto-js, session generator

### DIFF
--- a/__mocks__/crypto-js.js
+++ b/__mocks__/crypto-js.js
@@ -1,0 +1,10 @@
+module.exports = {
+  SHA256: function() {
+    return 'c1002b5096f243bd826abd55f542f49d5034cf87d8bc17da5522d47a1d808494'
+  },
+  enc: {
+    hex: function(){
+      return ''
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preset": "jest-react-native"
   },
   "dependencies": {
+    "crypto-js": "^3.1.9-1",    
     "panoptes-client": "^2.5.2",
     "ramda": "^0.22.1",
     "react": "~15.3.2",

--- a/src/actions/session.js
+++ b/src/actions/session.js
@@ -16,7 +16,7 @@ export function setSession() {
     store.get('@zooniverse:session').then(json => {
       stored = json.session
       if (stored.ttl < Date.now()) {
-        stored = generateSessionID()
+        stored.id = generateSessionID().id
       } else {
         stored.ttl = fiveMinutesFromNow()
       }

--- a/src/actions/session.js
+++ b/src/actions/session.js
@@ -1,0 +1,31 @@
+import store from 'react-native-simple-store'
+import { setState } from '../actions/index'
+import { generateSessionID, fiveMinutesFromNow } from '../utils/session'
+
+export function storeSession(session) {
+  return () => {
+    store.save('@zooniverse:session', {
+      session
+    })
+  }
+}
+
+export function setSession() {
+  return dispatch => {
+    let stored = {}
+    store.get('@zooniverse:session').then(json => {
+      stored = json.session
+      if (stored.ttl < Date.now()) {
+        stored = generateSessionID()
+      } else {
+        stored.ttl = fiveMinutesFromNow()
+      }
+
+      dispatch(storeSession(stored))
+      dispatch(setState('session', stored))
+    }).catch(() => { //nothing here, generate a new session ID
+      stored = generateSessionID()
+      dispatch(storeSession(stored))
+    })
+  }
+}

--- a/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
+++ b/src/components/__tests__/__snapshots__/OverlaySpinner-test.js.snap
@@ -3,6 +3,12 @@ exports[`test renders for isFetching 1`] = `
   style={undefined}>
   <Modal
     onRequestClose={[Function]}
+    supportedOrientations={
+      Array [
+        "landscape",
+        "portrait",
+      ]
+    }
     transparent={true}
     visible={true}>
     <View

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -7,6 +7,7 @@ import thunkMiddleware from 'redux-thunk'
 import {Scene, Router} from 'react-native-router-flux'
 import { setIsConnected, fetchProjects, setState } from '../actions/index'
 import { loadUserData } from '../actions/user'
+import { setSession } from '../actions/session'
 
 import ZooniverseApp from './zooniverseApp'
 import ProjectList from '../components/ProjectList'
@@ -25,6 +26,7 @@ const store = compose(applyMiddleware(thunkMiddleware))(createStore)(reducer)
 export default class App extends Component {
   componentDidMount() {
     store.dispatch(loadUserData())
+    store.dispatch(setSession())
 
     const handleAppStateChange = currentAppState => {
       if (currentAppState === 'active') {

--- a/src/utils/__tests__/utils-test.js
+++ b/src/utils/__tests__/utils-test.js
@@ -1,6 +1,7 @@
 import 'react-native'
 import { isValidEmail } from '../is-valid-email'
 import { isValidLogin } from '../is-valid-login'
+import { generateSessionID } from '../session'
 
 it('passes a good email', () => {
   let email = 'me@zooniverse.org'
@@ -40,4 +41,8 @@ it('fails a bad login - contains a dash', () => {
 it('fails a bad login - contains an apostrophe', () => {
   let login = `Bad'Login`
   expect(isValidLogin(login)).toBeFalsy()
+})
+
+it('generates a session ID of 64 chars using crypto', () => {
+  expect(generateSessionID().id).toHaveLength(64)
 })

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -1,0 +1,15 @@
+const CryptoJS = require('crypto-js')
+
+export function generateSessionID() {
+  const id = CryptoJS.SHA256('#{Math.random() * 10000 }#{Date.now()}#{Math.random() * 1000}').toString(CryptoJS.enc.Hex)
+  const ttl = fiveMinutesFromNow()
+
+  return  {id, ttl}
+}
+
+export function fiveMinutesFromNow(){
+  let d = new Date()
+  d.setMinutes(d.getMinutes() + 5)
+
+  return d
+}


### PR DESCRIPTION
Describe your changes.
Implements session generation for storing with classification data in the same manor as PFE.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

