### PR TITLE
Fix at older version of panoptes-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "preset": "jest-react-native"
   },
   "dependencies": {
-    "crypto-js": "^3.1.9-1",    
-    "panoptes-client": "^2.5.2",
+    "crypto-js": "^3.1.9-1",
+    "panoptes-client": "~2.5.2",
     "ramda": "^0.22.1",
     "react": "~15.3.2",
     "react-native": "~0.37.0",


### PR DESCRIPTION
Recently panoptes-client added using window.location:
https://github.com/zooniverse/panoptes-javascript-client/blob/master/lib/config.js#L63
which is causing an issue in mobile due to there being no window object since it's not a browser.  This fixes the version at 2.5.2 until a fix is in place.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

