### PR TITLE
Fix push issues in ios and android

### DIFF
--- a/android/app/src/main/java/com/zooniversemobile/MainActivity.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainActivity.java
@@ -71,11 +71,13 @@ public class MainActivity extends ReactActivity {
                 @Override
                 public void onMessageReceived(RemoteMessage remoteMessage) {
                 String projectID = String.valueOf(remoteMessage.getData().get("project_id"));
-                sendNotification(
-                    remoteMessage.getNotification().getTitle(),
-                    remoteMessage.getNotification().getBody(),
-                    projectID
-                );
+                if (remoteMessage.getNotification() != null) {
+                    sendNotification(
+                            remoteMessage.getNotification().getTitle(),
+                            remoteMessage.getNotification().getBody(),
+                            projectID
+                    );
+                }
                 }
             });
 

--- a/src/containers/zooniverseApp.js
+++ b/src/containers/zooniverseApp.js
@@ -55,8 +55,8 @@ class ZooniverseApp extends Component {
 
   onRemoteNotification = (notification) => {
     //this is called on iOS < 10 when registered, so make sure it's a valid push notification
-    var isValidIOS = Platform.OS === 'ios' && !pathOr(false, ['_data', 'pusher_token_validation'], notification)
-    var isValidAndroid = Platform.OS === 'android' && notification.title
+    let isValidIOS = Platform.OS === 'ios' && !pathOr(false, ['_data', 'pusher_token_validation'], notification)
+    let isValidAndroid = Platform.OS === 'android' && notification.title
 
     if (isValidIOS || isValidAndroid) {
       this.props.setNotificationPayload(notification)


### PR DESCRIPTION
Fixes a few issues in Android (identified by Laura) and that I noticed on iOS while testing that fix
  *  Fix so that Android doesn't send a notification when onMessageReceived unless it has a Notification.  I believe this is happening because pusher is sending a registration success message.  Currently this crashes android upon initial install. [Fixes #67]
  *  Fix so that Android and iOS < 10 doesn't erroneously display an empty message on registration success
  *  Fix iOS so that the interests are synced upon push notification registration.  This is to avoid a  race condition where the interests are synced prior to being prompted for registration, so that if a push notification is sent at the first install (and before any re-syncing occurs) the push notification won't go through.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

