### PR TITLE
Fix typo in saving project store

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -95,7 +95,7 @@ export function setProjectListFromStore() {
   return dispatch => {
     return new Promise ((resolve, reject) => {
       store.get('@zooniverse:projects').then(json => {
-        dispatch(setProjectList(json.projects))
+        dispatch(setProjectList(json.projectList))
         return resolve()
       }).catch(() => {
         return reject()


### PR DESCRIPTION
There was a typo where the item retrieved from local storage was called projects where it should've been projectList.  This was causing the project list to not be retrieved immediately from local storage, as intended.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

