### PR TITLE
Store workflow data

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -161,11 +161,22 @@ export function fetchProjectWorkflows(project) {
         const project = head(projects)
         project.get('workflows', {page_size: 100, active: true, fields: 'display_name'}).then((workflows) => {
           dispatch(setState(`projectWorkflows.${project.id}`, workflows))
+          dispatch(syncStore('projectWorkflows'))
           return resolve()
         }).catch((error) => {
           dispatch(setError('The following error occurred.  Please close down Zooniverse and try again.  If it persists please notify us.  \n\n' + error,))
           return resolve()
         })
+      })
+    })
+  }
+}
+
+export function loadProjectWorkflows() {
+  return (dispatch) => {
+    return new Promise((resolve) => {
+      dispatch(setFromStore('projectWorkflows')).then(() => {
+        return resolve()
       })
     })
   }

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -6,6 +6,7 @@ import { add, addIndex, filter, head, keys, map, reduce } from 'ramda'
 
 import { fetchProjectsByParms,
   loadNotificationSettings,
+  loadProjectWorkflows,
   loadSettings,
   setState } from '../actions/index'
 import { getAuthUser } from '../actions/auth'
@@ -39,6 +40,7 @@ export function loadUserData() {
         return Promise.all([
           dispatch(loadNotificationSettings()),
           dispatch(loadSettings()),
+          dispatch(loadProjectWorkflows()),
         ])
       } else {
         return Promise.all([
@@ -46,6 +48,7 @@ export function loadUserData() {
           dispatch(loadUserProjects()),
           dispatch(loadNotificationSettings()),
           dispatch(loadSettings()),
+          dispatch(loadProjectWorkflows()),
         ])
       }
     }).then(() => {


### PR DESCRIPTION
Project data is stored locally (in case a user has a slow / no internet connection), this adds functionality to store the workflow data as well, which is used to indicate that a project is mobile friendly and displays the mobile icon.  This way in case the api sync hasn't completed before the user visits a category it won't be jumpy or incorrectly go to the PFE project.
(it's probably easiest for comparison to merge #109 first, but I had to incorporate that to get it running in iOS)

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

