### PR TITLE
Add Classification Panel for Swipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "crypto-js": "^3.1.9-1",
     "panoptes-client": "^2.5.2",
+    "markdown-it": "^8.3.1",
+    "panoptes-client": "^2.5.2",
     "ramda": "^0.22.1",
     "react": "~15.3.2",
     "react-native": "~0.37.0",

--- a/src/actions/classifier.js
+++ b/src/actions/classifier.js
@@ -1,31 +1,33 @@
 import apiClient from 'panoptes-client/lib/api-client'
 import { isNil } from 'ramda'
-import { displayError, setState } from '../actions/index'
+import { setState } from '../actions/index'
 import { Actions } from 'react-native-router-flux'
+import { Alert } from 'react-native'
 
 export function startNewClassification(workflowID) {
   return (dispatch) => {
-    dispatch(setState('classifier.isFetching', true))
     dispatch(setState('loadingText', 'Loading Workflow...'))
     dispatch(setState('classifier.currentWorkflowID', workflowID))
     dispatch(fetchWorkflow(workflowID)).then(() => {
       dispatch(setState('classifier.isFetching', false))
-    }).catch((e) => {
-      dispatch(displayError(`Sorry, but there was an error loading this workflow.  Please try again later. ${e}`))
-      dispatch(setState('classifier.isFetching', false))
-      Actions.pop()  //go back to previous screen
+    }).catch(() => {
+      Alert.alert('Error', 'Sorry, but there was an error loading this workflow.  Please try again later.',
+        [{text: 'Go Back', onPress: () => { Actions.pop()}}]
+      )
     })
   }
 }
 
 export function fetchWorkflow(workflowID) {
   return (dispatch, getState) => {
-    return new Promise ((resolve) => {
+    return new Promise ((resolve, reject) => {
       if (isNil(getState().classifier.workflow[workflowID])) {
         return apiClient.type('workflows').get({id: workflowID}).then(([workflow]) => {
           dispatch(setState(`classifier.workflow.${workflowID}`, workflow))
           dispatch(setState(`classifier.tasks.${workflowID}`, workflow.tasks))
           return resolve()
+        }).catch((e) => {
+          return reject(e)
         })
       } else {
         return resolve()

--- a/src/actions/classifier.js
+++ b/src/actions/classifier.js
@@ -1,0 +1,35 @@
+import apiClient from 'panoptes-client/lib/api-client'
+import { isNil } from 'ramda'
+import { displayError, setState } from '../actions/index'
+import { Actions } from 'react-native-router-flux'
+
+export function startNewClassification(workflowID) {
+  return (dispatch) => {
+    dispatch(setState('classifier.isFetching', true))
+    dispatch(setState('loadingText', 'Loading Workflow...'))
+    dispatch(setState('classifier.currentWorkflowID', workflowID))
+    dispatch(fetchWorkflow(workflowID)).then(() => {
+      dispatch(setState('classifier.isFetching', false))
+    }).catch((e) => {
+      dispatch(displayError(`Sorry, but there was an error loading this workflow.  Please try again later. ${e}`))
+      dispatch(setState('classifier.isFetching', false))
+      Actions.pop()  //go back to previous screen
+    })
+  }
+}
+
+export function fetchWorkflow(workflowID) {
+  return (dispatch, getState) => {
+    return new Promise ((resolve) => {
+      if (isNil(getState().classifier.workflow[workflowID])) {
+        return apiClient.type('workflows').get({id: workflowID}).then(([workflow]) => {
+          dispatch(setState(`classifier.workflow.${workflowID}`, workflow))
+          dispatch(setState(`classifier.tasks.${workflowID}`, workflow.tasks))
+          return resolve()
+        })
+      } else {
+        return resolve()
+      }
+   })
+  }
+}

--- a/src/components/ClassificationPanel.js
+++ b/src/components/ClassificationPanel.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import {
+  Platform,
+  TouchableOpacity,
+  View
+} from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet'
+import StyledText from './StyledText'
+
+const topPadding = (Platform.OS === 'ios') ? 10 : 0
+
+class ClassificationPanel extends Component {
+  render() {
+    const tabs =
+      <View style={styles.tabContainer}>
+        <TouchableOpacity
+          style={[styles.tab]}>
+          <StyledText text={ 'QUESTION' } />
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, styles.deselectedTab]}>
+          <StyledText text={ 'TUTORIAL' } />
+        </TouchableOpacity>
+      </View>
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.panelContainer}>
+          { this.props.hasTutorial ? tabs : null }
+          { this.props.children }
+        </View>
+      </View>
+    )
+  }
+}
+
+const styles = EStyleSheet.create({
+  $tabHeight: 32,
+  $panelMargin: 13,
+  container: {
+    backgroundColor: '$lightestGrey',
+    flex: 1,
+    marginTop: 60,
+    paddingTop: topPadding,
+    paddingBottom: 0,
+  },
+  panelContainer: {
+    flex: 1,
+    backgroundColor: 'white',
+    margin: '$panelMargin',
+    marginBottom: 0,
+  },
+  tabContainer: {
+    height: '$tabHeight',
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+  tab: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '$tabHeight',
+    width: '50% - $panelMargin',
+    marginTop: 1,
+  },
+  deselectedTab: {
+    backgroundColor: '$lightestGrey',
+  }
+})
+
+ClassificationPanel.propTypes = {
+  isFetching: React.PropTypes.bool,
+  hasTutorial: React.PropTypes.bool,
+  children: React.PropTypes.node
+}
+export default ClassificationPanel

--- a/src/components/OverlaySpinner.js
+++ b/src/components/OverlaySpinner.js
@@ -16,7 +16,11 @@ export class OverlaySpinner extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Spinner visible={this.props.isFetching} textContent={this.props.loadingText} textStyle={styles.text} />
+        <Spinner
+          visible={this.props.isFetching || this.props.overrideVisibility}
+          textContent={this.props.loadingText}
+          textStyle={styles.text}
+        />
       </View>
     );
   }
@@ -37,6 +41,11 @@ const styles = EStyleSheet.create({
 OverlaySpinner.propTypes = {
   isFetching: React.PropTypes.bool,
   loadingText: React.PropTypes.string,
+  overrideVisibility: React.PropTypes.bool
+}
+
+OverlaySpinner.defaultProps = {
+  overrideVisibility: false
 }
 
 export default connect(mapStateToProps)(OverlaySpinner)

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -16,7 +16,7 @@ import Icon from 'react-native-vector-icons/FontAwesome'
 import WorkflowPrompt from './WorkflowPrompt'
 import Workflow from './Workflow'
 import PopupMessage from './PopupMessage'
-import { addIndex, length, map } from 'ramda'
+import { addIndex, head, length, map } from 'ramda'
 
 const DEFAULT_BOX_HEIGHT = 269
 const MARGIN_BOTTOM = 25
@@ -66,6 +66,8 @@ class Project extends Component {
 
     if ((hasMixedWorkflows && this.props.promptForWorkflow)) {
       this.setState({showWorkflowPrompt: true})
+    } else if (hasSingleMobileWorkflow) {
+      Actions.SwipeClassifier({ workflowID: head(this.props.mobileWorkflows).id })
     } else if (length(this.props.mobileWorkflows) > 1) {
       this.setState({ errorPopupVisible: true })
     } else {
@@ -95,7 +97,7 @@ class Project extends Component {
   }
 
   openMobileProject(workflowID) {
-    //TODO: Send to classify (next PR) Actions.Classify({ workflowID: workflowID })
+    Actions.SwipeClassifier({ workflowID: workflowID })
   }
 
   setHeight(height) {

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -31,7 +31,7 @@ export class Question extends Component {
             extraCSS={ 'p {font-size: 14px; font-weight: 500; margin: 5px 0 0;}' }
             markdown={ this.props.question }
             width={ Dimensions.get('window').width - 100 }
-            onResize={ (newHeight) => this.props.setQuestionContainerHeight(newHeight) }
+            onReceivedHeight={ (newHeight) => this.props.setQuestionContainerHeight(newHeight) }
           />
         </View>
       </View>

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import {
+  Dimensions,
+  View
+} from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet'
+import StyledMarkdown from './StyledMarkdown'
+import { connect } from 'react-redux'
+import { setState } from '../actions/index'
+
+//questionContainerHeight is stored in redux because the swipeable component needs
+//to be absolutely positioned outside of the ContainerPanel for Android
+//This is to help calculate that height
+
+const mapStateToProps = (state, ownProps) => ({
+  questionContainerHeight: state.classifier.questionContainerHeight[ownProps.workflowID] || 0,
+})
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  setQuestionContainerHeight(height) {
+    dispatch(setState(`classifier.questionContainerHeight.${ownProps.workflowID}`, height))
+  },
+})
+
+export class Question extends Component {
+  render() {
+    return (
+      <View style={[styles.questionContainer, { height: this.props.questionContainerHeight }]}>
+        <View style={styles.question}>
+          <StyledMarkdown
+            extraCSS={ 'p {font-size: 14px; font-weight: 500; margin: 5px 0 0;}' }
+            markdown={ this.props.question }
+            width={ Dimensions.get('window').width - 100 }
+            onResize={ (newHeight) => this.props.setQuestionContainerHeight(newHeight) }
+          />
+        </View>
+      </View>
+    )
+  }
+}
+
+const styles = EStyleSheet.create({
+  questionContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+    marginTop: 10,
+    marginHorizontal: 20,
+  },
+  question: {
+    flex: 1,
+    width: '100%',
+  },
+})
+
+Question.propTypes = {
+  question: React.PropTypes.string,
+  workflowID: React.PropTypes.string,
+  setQuestionContainerHeight: React.PropTypes.func,
+  questionContainerHeight: React.PropTypes.number,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Question)

--- a/src/components/StyledMarkdown.js
+++ b/src/components/StyledMarkdown.js
@@ -13,17 +13,18 @@ import { removeMDTab } from '../utils/remove-md-tab'
 const MarkdownIt = require('markdown-it'),
     md = new MarkdownIt({ linkify: true, breaks: true }).use(removeMDTab)
 
-const WEBVIEW_REF = 'WEBVIEW_REF'
-
 class StyledMarkdown extends React.Component {
+  webview = null
+
   constructor(props) {
     super(props)
     this.state = { height: 0 }
+
   }
 
   onShouldStartLoadWithRequest = (event) => {
     if (event.url.indexOf('http') >= 0 ) {
-      this.refs[WEBVIEW_REF].stopLoading()
+      this.webview.stopLoading()
       Linking.openURL(event.url)
       return false
     } else {
@@ -58,7 +59,7 @@ class StyledMarkdown extends React.Component {
 
     const webviewComponent =
       <WebView
-        ref={WEBVIEW_REF}
+        ref={webview => { this.webview = webview }}
         style={ [styles.webview, { height: this.state.height, width: displayWidth }] }
 				source={{
 					html: resultHTML,

--- a/src/components/StyledMarkdown.js
+++ b/src/components/StyledMarkdown.js
@@ -21,6 +21,27 @@ class StyledMarkdown extends React.Component {
     this.state = { height: 0 }
   }
 
+  onShouldStartLoadWithRequest = (event) => {
+    if (event.url.indexOf('http') >= 0 ) {
+      this.refs[WEBVIEW_REF].stopLoading()
+      Linking.openURL(event.url)
+      return false
+    } else {
+      return true
+    }
+  }
+
+  onNavigationStateChange = (navState) => {
+    if (Platform.OS === 'android') {
+      this.onShouldStartLoadWithRequest(navState)
+    }
+    if (Number(navState.title) > 0) {
+      const htmlHeight = Number(navState.title) //convert to number
+      this.setState({height: htmlHeight})
+      this.props.onReceivedHeight(htmlHeight)
+    }
+  }
+
   render() {
     //Markdownz uses markdown-it-imsize for image sizes, however this package
     //requires fs, which is a node core module and not available natively
@@ -55,27 +76,6 @@ class StyledMarkdown extends React.Component {
       resultHTML ? webviewComponent : null
     )
   }
-
-  onShouldStartLoadWithRequest = (event) => {
-    if (event.url.indexOf('http') >= 0 ) {
-      this.refs[WEBVIEW_REF].stopLoading()
-      Linking.openURL(event.url)
-      return false
-    } else {
-      return true
-    }
-  }
-
-  onNavigationStateChange = (navState) => {
-    if (Platform.OS === 'android') {
-      this.onShouldStartLoadWithRequest(navState)
-    }
-    if (Number(navState.title) > 0) {
-      const htmlHeight = Number(navState.title) //convert to number
-      this.setState({height: htmlHeight})
-      this.props.onResize(htmlHeight)
-    }
-  }
 }
 
 const styles = EStyleSheet.create({
@@ -86,7 +86,7 @@ const styles = EStyleSheet.create({
 
 StyledMarkdown.propTypes = {
   markdown: React.PropTypes.string,
-  onResize: React.PropTypes.func,
+  onReceivedHeight: React.PropTypes.func,
   extraCSS: React.PropTypes.string,
   width: React.PropTypes.number,
 }
@@ -94,7 +94,7 @@ StyledMarkdown.propTypes = {
 StyledMarkdown.defaultProps = {
   markdown: '',
   extraCSS: '',
-  onResize: () => {},
+  onReceivedHeight: () => {},
 }
 
 export default StyledMarkdown

--- a/src/components/StyledMarkdown.js
+++ b/src/components/StyledMarkdown.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import {
+  Dimensions,
+  Linking,
+  Platform,
+  WebView,
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import defaultHTML from '../utils/default-md-html'
+
+import { removeMDTab } from '../utils/remove-md-tab'
+
+const MarkdownIt = require('markdown-it'),
+    md = new MarkdownIt({ linkify: true, breaks: true }).use(removeMDTab)
+
+const WEBVIEW_REF = 'WEBVIEW_REF'
+
+class StyledMarkdown extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { height: 0 }
+  }
+
+  render() {
+    //Markdownz uses markdown-it-imsize for image sizes, however this package
+    //requires fs, which is a node core module and not available natively
+    //Also, we can't use the image sizes.  This regexp removes them, prior to
+    //being sent to renderer, or else they're interpreted as links
+    let markdown = this.props.markdown.replace(/ =[0-9]+x[0-9]*\)/g, '\)')
+    let result = md.render(markdown)
+
+    const resultHTML = defaultHTML
+      .replace('$body', result)
+      .replace('$extraCSS', this.props.extraCSS)
+
+    const displayWidth = this.props.width || Dimensions.get('window').width - 40
+
+    const webviewComponent =
+      <WebView
+        ref={WEBVIEW_REF}
+        style={ [styles.webview, { height: this.state.height, width: displayWidth }] }
+				source={{
+					html: resultHTML,
+					baseUrl: 'about:blank'
+				}}
+        javaScriptEnabled={ true }
+        domStorageEnabled={ true }
+				automaticallyAdjustContentInsets={ true }
+        scalesPageToFit={ true }
+        onShouldStartLoadWithRequest={this.onShouldStartLoadWithRequest}
+        onNavigationStateChange={this.onNavigationStateChange}
+			/>
+
+    return (
+      resultHTML ? webviewComponent : null
+    )
+  }
+
+  onShouldStartLoadWithRequest = (event) => {
+    if (event.url.indexOf('http') >= 0 ) {
+      this.refs[WEBVIEW_REF].stopLoading()
+      Linking.openURL(event.url)
+      return false
+    } else {
+      return true
+    }
+  }
+
+  onNavigationStateChange = (navState) => {
+    if (Platform.OS === 'android') {
+      this.onShouldStartLoadWithRequest(navState)
+    }
+    if (Number(navState.title) > 0) {
+      const htmlHeight = Number(navState.title) //convert to number
+      this.setState({height: htmlHeight})
+      this.props.onResize(htmlHeight)
+    }
+  }
+}
+
+const styles = EStyleSheet.create({
+  webview: {
+    backgroundColor: 'transparent'
+  },
+})
+
+StyledMarkdown.propTypes = {
+  markdown: React.PropTypes.string,
+  onResize: React.PropTypes.func,
+  extraCSS: React.PropTypes.string,
+  width: React.PropTypes.number,
+}
+
+StyledMarkdown.defaultProps = {
+  markdown: '',
+  extraCSS: '',
+  onResize: () => {},
+}
+
+export default StyledMarkdown

--- a/src/components/SwipeClassifier.js
+++ b/src/components/SwipeClassifier.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import ClassificationPanel from './ClassificationPanel'
+import Question from './Question'
+import OverlaySpinner from './OverlaySpinner'
+import NavBar from './NavBar'
+import { setState } from '../actions/index'
+import { startNewClassification } from '../actions/classifier'
+
+const mapStateToProps = (state, ownProps) => ({
+  isFetching: state.classifier.isFetching,
+  workflow: state.classifier.workflow[ownProps.workflowID] || {},
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  startNewClassification(workflowID) {
+    dispatch(startNewClassification(workflowID))
+  },
+  setIsFetching(isFetching) {
+    dispatch(setState('classifier.isFetching', isFetching))
+  },
+})
+
+export class SwipeClassifier extends React.Component {
+  componentWillMount() {
+    this.props.setIsFetching(true)
+    this.props.startNewClassification(this.props.workflowID)
+  }
+
+  static renderNavigationBar() {
+    return <NavBar title={'Classify'} showBack={true} />;
+  }
+
+  render() {
+    const renderClassifier = () => {
+      const key = this.props.workflow.first_task //always just one task
+      const task = this.props.workflow.tasks[key]
+      return (
+        <ClassificationPanel
+          isFetching={ this.props.isFetching }
+          hasTutorial = { false }>
+          <Question question={task.question} workflowID={this.props.workflowID} />
+        </ClassificationPanel>
+      )
+    }
+
+    return (
+        this.props.isFetching ? <OverlaySpinner overrideVisibility={this.props.isFetching} /> : renderClassifier()
+    )
+  }
+}
+
+SwipeClassifier.propTypes = {
+  isFetching: React.PropTypes.bool,
+  workflowID: React.PropTypes.string,
+  workflow: React.PropTypes.shape({
+    first_task: React.PropTypes.string,
+    tasks: React.PropTypes.object,
+  }),
+  startNewClassification: React.PropTypes.func,
+  setIsFetching: React.PropTypes.func,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SwipeClassifier)

--- a/src/components/__tests__/ClassificationPanel-test.js
+++ b/src/components/__tests__/ClassificationPanel-test.js
@@ -1,0 +1,11 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ClassificationPanel from '../ClassificationPanel'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <ClassificationPanel />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/Question-test.js
+++ b/src/components/__tests__/Question-test.js
@@ -1,0 +1,16 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+jest.mock('WebView', () => 'WebView')
+import { Question } from '../Question'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <Question
+      question={'Is this this?'}
+      questionContainerHeight={25}
+      setQuestionContainerHeight={jest.fn}
+      />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/StyledMarkdown-test.js
+++ b/src/components/__tests__/StyledMarkdown-test.js
@@ -1,0 +1,22 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+jest.mock('WebView', () => 'WebView')
+
+import StyledMarkdown from '../StyledMarkdown'
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <StyledMarkdown markdown={'What?'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+
+it('renders extraCSS', () => {
+  const tree = renderer.create(
+    <StyledMarkdown markdown={'who?'} extraCSS={'font-size: 30;'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/SwipeClassifier-test.js
+++ b/src/components/__tests__/SwipeClassifier-test.js
@@ -1,0 +1,42 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+jest.mock('WebView', () => 'WebView')
+jest.mock('../OverlaySpinner', () => 'OverlaySpinner')
+jest.mock('../Question', () => 'Question')
+
+import { SwipeClassifier } from '../SwipeClassifier'
+
+const workflow = {
+  first_task: 'T0',
+  tasks: {
+    T0: {
+      question: 'What was that?'
+    }
+  }
+}
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <SwipeClassifier
+      isFetching={false}
+      setIsFetching={jest.fn}
+      startNewClassification={jest.fn}
+      workflow={workflow}
+      workflowID={'1'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders spinner if fetching', () => {
+  const tree = renderer.create(
+    <SwipeClassifier
+      isFetching={true}
+      setIsFetching={jest.fn}
+      startNewClassification={jest.fn}
+      workflow={workflow}
+      workflowID={'1'} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/ClassificationPanel-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ClassificationPanel-test.js.snap
@@ -1,0 +1,7 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined} />
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/Question-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Question-test.js.snap
@@ -1,0 +1,114 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={
+    Array [
+      undefined,
+      Object {
+        "height": 25,
+      },
+    ]
+  }>
+  <View
+    style={undefined}>
+    <WebView
+      automaticallyAdjustContentInsets={true}
+      domStorageEnabled={true}
+      javaScriptEnabled={true}
+      onNavigationStateChange={[Function]}
+      onShouldStartLoadWithRequest={[Function]}
+      scalesPageToFit={true}
+      source={
+        Object {
+          "baseUrl": "about:blank",
+          "html": "<!DOCTYPE html>
+        <html>
+            <head>
+                <meta charset=\"utf-8\">
+                <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
+                <meta name=\"viewport\" content=\"initial-scale=1, maximum-scale=1\">
+                <meta name=\"format-detection\" content=\"telephone=no\">
+                <meta name=\"format-detection\" content=\"date=no\">
+                <meta name=\"format-detection\" content=\"address=no\">
+                <meta name=\"format-detection\" content=\"email=no\">
+        
+                <title></title>
+        
+        
+                <style type=\"text/css\">
+                    body, html, #height-wrapper {
+                        margin: 0;
+                        padding: 0;
+                    }
+                    #height-wrapper {
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                    }
+                    body {
+                        font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                    }
+                    b, strong {
+                        font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                        font-weight: bold;
+                    }
+                    h1, h2, h3, h4, h5, h6 {
+                        margin-top: 10px;
+                        font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                        font-weight: 500;
+                    }
+                    img {
+                      height: auto;
+                      width: auto;
+                      max-width: 300px;
+                      max-height: 300px;
+                    }
+                    p {
+                      margin: 0;
+                    }
+                    p {font-size: 14px; font-weight: 500; margin: 5px 0 0;}
+                </style>
+            </head>
+            <body>
+                <p>Is this this?</p>
+        
+        
+            <script>
+        
+            ;(function() {
+            var wrapper = document.createElement(\"div\");
+            wrapper.id = \"height-wrapper\";
+            while (document.body.firstChild) {
+                wrapper.appendChild(document.body.firstChild);
+            }
+            document.body.appendChild(wrapper);
+            var i = 0;
+            function updateHeight() {
+                document.title = wrapper.clientHeight;
+                window.location.hash = ++i;
+            }
+            updateHeight();
+            window.addEventListener(\"load\", function() {
+                updateHeight();
+                setTimeout(updateHeight, 1000);
+            });
+            window.addEventListener(\"resize\", updateHeight);
+            }());
+        
+            </script>
+            </body>
+        </html>",
+        }
+      }
+      style={
+        Array [
+          undefined,
+          Object {
+            "height": 0,
+            "width": 275,
+          },
+        ]
+      } />
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/StyledMarkdown-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledMarkdown-test.js.snap
@@ -1,0 +1,203 @@
+exports[`test renders correctly 1`] = `
+<WebView
+  automaticallyAdjustContentInsets={true}
+  domStorageEnabled={true}
+  javaScriptEnabled={true}
+  onNavigationStateChange={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
+  scalesPageToFit={true}
+  source={
+    Object {
+      "baseUrl": "about:blank",
+      "html": "<!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset=\"utf-8\">
+            <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
+            <meta name=\"viewport\" content=\"initial-scale=1, maximum-scale=1\">
+            <meta name=\"format-detection\" content=\"telephone=no\">
+            <meta name=\"format-detection\" content=\"date=no\">
+            <meta name=\"format-detection\" content=\"address=no\">
+            <meta name=\"format-detection\" content=\"email=no\">
+    
+            <title></title>
+    
+    
+            <style type=\"text/css\">
+                body, html, #height-wrapper {
+                    margin: 0;
+                    padding: 0;
+                }
+                #height-wrapper {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                }
+                body {
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                }
+                b, strong {
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                    font-weight: bold;
+                }
+                h1, h2, h3, h4, h5, h6 {
+                    margin-top: 10px;
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                    font-weight: 500;
+                }
+                img {
+                  height: auto;
+                  width: auto;
+                  max-width: 300px;
+                  max-height: 300px;
+                }
+                p {
+                  margin: 0;
+                }
+                
+            </style>
+        </head>
+        <body>
+            <p>What?</p>
+    
+    
+        <script>
+    
+        ;(function() {
+        var wrapper = document.createElement(\"div\");
+        wrapper.id = \"height-wrapper\";
+        while (document.body.firstChild) {
+            wrapper.appendChild(document.body.firstChild);
+        }
+        document.body.appendChild(wrapper);
+        var i = 0;
+        function updateHeight() {
+            document.title = wrapper.clientHeight;
+            window.location.hash = ++i;
+        }
+        updateHeight();
+        window.addEventListener(\"load\", function() {
+            updateHeight();
+            setTimeout(updateHeight, 1000);
+        });
+        window.addEventListener(\"resize\", updateHeight);
+        }());
+    
+        </script>
+        </body>
+    </html>",
+    }
+  }
+  style={
+    Array [
+      undefined,
+      Object {
+        "height": 0,
+        "width": 335,
+      },
+    ]
+  } />
+`;
+
+exports[`test renders extraCSS 1`] = `
+<WebView
+  automaticallyAdjustContentInsets={true}
+  domStorageEnabled={true}
+  javaScriptEnabled={true}
+  onNavigationStateChange={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
+  scalesPageToFit={true}
+  source={
+    Object {
+      "baseUrl": "about:blank",
+      "html": "<!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset=\"utf-8\">
+            <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
+            <meta name=\"viewport\" content=\"initial-scale=1, maximum-scale=1\">
+            <meta name=\"format-detection\" content=\"telephone=no\">
+            <meta name=\"format-detection\" content=\"date=no\">
+            <meta name=\"format-detection\" content=\"address=no\">
+            <meta name=\"format-detection\" content=\"email=no\">
+    
+            <title></title>
+    
+    
+            <style type=\"text/css\">
+                body, html, #height-wrapper {
+                    margin: 0;
+                    padding: 0;
+                }
+                #height-wrapper {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                }
+                body {
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                }
+                b, strong {
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                    font-weight: bold;
+                }
+                h1, h2, h3, h4, h5, h6 {
+                    margin-top: 10px;
+                    font-family: \"Open Sans\", \"Gill Sans\", Arial, sans-serif;
+                    font-weight: 500;
+                }
+                img {
+                  height: auto;
+                  width: auto;
+                  max-width: 300px;
+                  max-height: 300px;
+                }
+                p {
+                  margin: 0;
+                }
+                font-size: 30;
+            </style>
+        </head>
+        <body>
+            <p>who?</p>
+    
+    
+        <script>
+    
+        ;(function() {
+        var wrapper = document.createElement(\"div\");
+        wrapper.id = \"height-wrapper\";
+        while (document.body.firstChild) {
+            wrapper.appendChild(document.body.firstChild);
+        }
+        document.body.appendChild(wrapper);
+        var i = 0;
+        function updateHeight() {
+            document.title = wrapper.clientHeight;
+            window.location.hash = ++i;
+        }
+        updateHeight();
+        window.addEventListener(\"load\", function() {
+            updateHeight();
+            setTimeout(updateHeight, 1000);
+        });
+        window.addEventListener(\"resize\", updateHeight);
+        }());
+    
+        </script>
+        </body>
+    </html>",
+    }
+  }
+  style={
+    Array [
+      undefined,
+      Object {
+        "height": 0,
+        "width": 335,
+      },
+    ]
+  } />
+`;

--- a/src/components/__tests__/__snapshots__/SwipeClassifier-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SwipeClassifier-test.js.snap
@@ -1,0 +1,16 @@
+exports[`test renders correctly 1`] = `
+<View
+  style={undefined}>
+  <View
+    style={undefined}>
+    <Question
+      question="What was that?"
+      workflowID="1" />
+  </View>
+</View>
+`;
+
+exports[`test renders spinner if fetching 1`] = `
+<OverlaySpinner
+  overrideVisibility={true} />
+`;

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -20,6 +20,7 @@ import Settings from '../components/Settings'
 import SideDrawer from '../components/SideDrawer'
 import ZooWebView from '../components/ZooWebView'
 import Onboarding from '../components/Onboarding'
+import SwipeClassifier from '../components/SwipeClassifier'
 
 const store = compose(applyMiddleware(thunkMiddleware))(createStore)(reducer)
 
@@ -40,8 +41,6 @@ export default class App extends Component {
       store.dispatch(setState('isConnected', isConnected))
       NetInfo.isConnected.addEventListener('change', dispatchConnected)
     })
-
-
     store.dispatch(fetchProjects())
   }
 
@@ -61,6 +60,7 @@ export default class App extends Component {
               <Scene key="Settings" component={Settings} />
               <Scene key="ZooWebView" hideNavBar={true} component={ZooWebView} duration={0} />
               <Scene key="Onboarding" component={Onboarding} duration={0} hideNavBar={true} sceneConfig={Navigator.SceneConfigs.FloatFromLeft} />
+              <Scene key="SwipeClassifier" component={SwipeClassifier} panHandlers={null} />
             </Scene>
           </Scene>
         </Router>

--- a/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
+++ b/src/reducers/__tests__/__snapshots__/reducers-test.js.snap
@@ -1,6 +1,12 @@
 exports[`test sets a new state 1`] = `
 Object {
   "bobLoblaw": "Has a law blog",
+  "classifier": Object {
+    "currentWorkflowID": 0,
+    "isFetching": true,
+    "questionContainerHeight": Object {},
+    "workflow": Object {},
+  },
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
@@ -9,7 +15,7 @@ Object {
   "notifications": Object {
     "general": true,
   },
-  "projectList": Array [],
+  "projectList": Object {},
   "projectWorkflows": Object {},
   "pushEnabled": false,
   "pushPrompted": false,
@@ -28,6 +34,12 @@ Object {
 
 exports[`test sets state from initial state 1`] = `
 Object {
+  "classifier": Object {
+    "currentWorkflowID": 0,
+    "isFetching": true,
+    "questionContainerHeight": Object {},
+    "workflow": Object {},
+  },
   "errorMessage": null,
   "isConnected": true,
   "isFetching": false,
@@ -36,7 +48,7 @@ Object {
   "notifications": Object {
     "general": true,
   },
-  "projectList": Array [],
+  "projectList": Object {},
   "projectWorkflows": Object {},
   "pushEnabled": false,
   "pushPrompted": false,
@@ -55,6 +67,12 @@ Object {
 
 exports[`test sets user 1`] = `
 Object {
+  "classifier": Object {
+    "currentWorkflowID": 0,
+    "isFetching": true,
+    "questionContainerHeight": Object {},
+    "workflow": Object {},
+  },
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
@@ -63,7 +81,7 @@ Object {
   "notifications": Object {
     "general": true,
   },
-  "projectList": Array [],
+  "projectList": Object {},
   "projectWorkflows": Object {},
   "pushEnabled": false,
   "pushPrompted": false,
@@ -85,6 +103,12 @@ Object {
 
 exports[`test unsets user 1`] = `
 Object {
+  "classifier": Object {
+    "currentWorkflowID": 0,
+    "isFetching": true,
+    "questionContainerHeight": Object {},
+    "workflow": Object {},
+  },
   "errorMessage": null,
   "isConnected": null,
   "isFetching": false,
@@ -93,7 +117,7 @@ Object {
   "notifications": Object {
     "general": true,
   },
-  "projectList": Array [],
+  "projectList": Object {},
   "projectWorkflows": Object {},
   "pushEnabled": false,
   "pushPrompted": false,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,7 +7,7 @@ export const InitialState = {
   errorMessage: null,
   isConnected: null,
   selectedDiscipline: null,
-  projectList: [],
+  projectList: {},
   projectWorkflows: {},
   webViewNavCounter: 0,
   notificationProject: {},
@@ -17,6 +17,12 @@ export const InitialState = {
   settings: { promptForWorkflow: false },
   pushEnabled: false,
   pushPrompted: false,
+  classifier: { //key is workflow ID for each
+    isFetching: true,
+    currentWorkflowID: 0,
+    workflow: {},
+    questionContainerHeight: {},
+  },
 }
 
 export default function(state=InitialState, action) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -22,5 +22,5 @@ export default {
   darkTeal: 'rgba(0, 116, 130, 1)',
   lightestGrey: '#EFF3F6',
   darkGrey: '#5C5C5C',
-  disabledIconColor: '#D5DCE4',   
+  disabledIconColor: '#D5DCE4',
 }

--- a/src/utils/default-md-html.js
+++ b/src/utils/default-md-html.js
@@ -1,0 +1,77 @@
+module.exports = `<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+        <meta name="format-detection" content="telephone=no">
+        <meta name="format-detection" content="date=no">
+        <meta name="format-detection" content="address=no">
+        <meta name="format-detection" content="email=no">
+
+        <title></title>
+
+
+        <style type="text/css">
+            body, html, #height-wrapper {
+                margin: 0;
+                padding: 0;
+            }
+            #height-wrapper {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+            }
+            body {
+                font-family: "Open Sans", "Gill Sans", Arial, sans-serif;
+            }
+            b, strong {
+                font-family: "Open Sans", "Gill Sans", Arial, sans-serif;
+                font-weight: bold;
+            }
+            h1, h2, h3, h4, h5, h6 {
+                margin-top: 10px;
+                font-family: "Open Sans", "Gill Sans", Arial, sans-serif;
+                font-weight: 500;
+            }
+            img {
+              height: auto;
+              width: auto;
+              max-width: 300px;
+              max-height: 300px;
+            }
+            p {
+              margin: 0;
+            }
+            $extraCSS
+        </style>
+    </head>
+    <body>
+        $body
+
+    <script>
+
+    ;(function() {
+    var wrapper = document.createElement("div");
+    wrapper.id = "height-wrapper";
+    while (document.body.firstChild) {
+        wrapper.appendChild(document.body.firstChild);
+    }
+    document.body.appendChild(wrapper);
+    var i = 0;
+    function updateHeight() {
+        document.title = wrapper.clientHeight;
+        window.location.hash = ++i;
+    }
+    updateHeight();
+    window.addEventListener("load", function() {
+        updateHeight();
+        setTimeout(updateHeight, 1000);
+    });
+    window.addEventListener("resize", updateHeight);
+    }());
+
+    </script>
+    </body>
+</html>`

--- a/src/utils/remove-md-tab.js
+++ b/src/utils/remove-md-tab.js
@@ -1,0 +1,20 @@
+export function removeMDTab(md) {
+  // Remember old renderer, if overridden, or proxy to default renderer
+  let defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options)
+  }
+
+  let prefix = '+tab+'
+
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    let hrefIndex = tokens[idx].attrIndex('href')
+    let href = tokens[idx].attrs[hrefIndex][1]
+    if (prefix === href.slice(0, prefix.length)) {
+        // trim prefix if href starts with prefix
+      tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length)
+    }
+
+    // pass token to default renderer
+    return defaultRender(tokens, idx, options, env, self)
+  };
+}


### PR DESCRIPTION
In an attempt to make this PR smaller I've pulled out the presentational base of the swipe app.  This doesn't include the Tutorial, Guide or subject swipe (those will be in later PRs)

Adds markdown support which is used in multiple places in the classifier (the question, field guide, tutorial).   I attempted several react-native markdown libraries but none were close enough or customizable enough to the markdownz rendering - and so I settled for using a combination of webview and the markdown-it library

  *  default-md-html.js used as a basic html template for all markdown being rendered using webview.  It includes a method to set the height because webview requires an explicit height, but we don't know the height until the markdown has been rendered.
  *  remove-md-tab.js is a plugin for markdown-it, copied mostly from the markdownz lib/lib/links-in-new-tabs.js except that it removes the +tab+ since we don't want it opening a new tab for webview


# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

