### PR TITLE
Allow panoptes client to be most recent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "crypto-js": "^3.1.9-1",
-    "panoptes-client": "~2.5.2",
+    "panoptes-client": "^2.5.2",
     "ramda": "^0.22.1",
     "react": "~15.3.2",
     "react-native": "~0.37.0",


### PR DESCRIPTION
Since the fix for panoptes-client went in that no longer relies on window we can reinstate the panoptes client to use the most recent.

[Fixes #106]

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

