### PR TITLE
Fix user auth error

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -11,6 +11,10 @@ import {
 import { loadUserAvatar, loadUserProjects, syncUserStore } from '../actions/user'
 
 export function getAuthUser() {
+  //prevent red screen of death thrown by a console.error in javascript-client
+  /* eslint-disable no-console */
+  console.reportErrorsAsExceptions = false
+
   return () => {
     return new Promise ((resolve, reject) => {
       auth.checkCurrent().then ((user) => {

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -43,13 +43,18 @@ export function loadUserData() {
           dispatch(loadProjectWorkflows()),
         ])
       } else {
-        return Promise.all([
-          dispatch(loadUserAvatar()),
-          dispatch(loadUserProjects()),
-          dispatch(loadNotificationSettings()),
-          dispatch(loadSettings()),
-          dispatch(loadProjectWorkflows()),
-        ])
+        dispatch(getAuthUser()).then(() => {
+          return Promise.all([
+            dispatch(loadUserAvatar()),
+            dispatch(loadUserProjects()),
+            dispatch(loadNotificationSettings()),
+            dispatch(loadSettings()),
+            dispatch(loadProjectWorkflows()),
+          ])
+        }).catch(() => {
+          dispatch(setState('errorMessage', ''))
+          Actions.SignIn()
+        })
       }
     }).then(() => {
       dispatch(syncUserStore())


### PR DESCRIPTION
Fixes an issue where users that can't auth will receive an error.  (this appears to just happen in dev when switching environments).  Rather than displaying an error this will redirect to the sign in page if the user isn't logged in.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

