### PR TITLE
Add ability to view the subject full screen and zoom if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-native-extended-stylesheet": "^0.3.0",
     "react-native-fcm": "^2.5.0",
     "react-native-google-analytics-bridge": "^4.0.2",
+    "react-native-image-pan-zoom": "^1.1.12",
     "react-native-loading-spinner-overlay": "^0.4.1",
     "react-native-orientation": "^1.17.0",
     "react-native-router-flux": "~3.35.0",

--- a/src/components/FullScreenImage.js
+++ b/src/components/FullScreenImage.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import {
+  Modal,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import ZoomableImage from './ZoomableImage'
+import Icon from 'react-native-vector-icons/FontAwesome'
+import StyledText from './StyledText'
+
+class FullScreenImage extends React.Component {
+  render() {
+    const zoomMessage =
+      <View style={styles.rowContainer}>
+        <Icon name="info-circle" style={styles.infoIcon} />
+        <StyledText additionalStyles={[styles.message]} text='You can zoom into this image' />
+      </View>
+
+    return (
+      <Modal
+        animationType={'fade'}
+        transparent={true}
+        onRequestClose={() => {}}
+        visible={this.props.isVisible}>
+        <View style={styles.container}>
+          <ZoomableImage
+            source={this.props.source}
+            handlePress={this.props.handlePress}
+            allowPanAndZoom={!!this.props.allowPanAndZoom} />
+          {this.props.allowPanAndZoom ? zoomMessage : null}
+          <TouchableOpacity
+            activeOpacity={0.5}
+            onPress={this.props.handlePress}
+            style={styles.closeIcon}>
+            <Icon name="times" style={styles.icon} />
+          </TouchableOpacity>
+        </View>
+      </Modal>
+    );
+  }
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start',
+  },
+  closeIcon: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    top: 13,
+    right: 5
+  },
+  icon: {
+    backgroundColor: 'transparent',
+    color: 'white',
+    fontSize: 24,
+    padding: 15,
+  },
+  rowContainer: {
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    position: 'absolute',
+    bottom: 10,
+    left: 10,
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  message: {
+    color: 'white',
+  },
+  infoIcon: {
+    color: '$transluscentWhite',
+    fontSize: 20,
+    padding: 5,
+  }
+})
+
+FullScreenImage.propTypes = {
+  source: React.PropTypes.object,
+  isVisible: React.PropTypes.bool,
+  handlePress: React.PropTypes.func,
+  allowPanAndZoom: React.PropTypes.bool
+}
+
+export default FullScreenImage

--- a/src/components/SwipeClassifier.js
+++ b/src/components/SwipeClassifier.js
@@ -13,6 +13,7 @@ import SwipeSubject from './SwipeSubject'
 import SwipeTabs from './SwipeTabs'
 import OverlaySpinner from './OverlaySpinner'
 import NavBar from './NavBar'
+import FullScreenImage from './FullScreenImage'
 import { setState } from '../actions/index'
 import { startNewClassification, setTutorialCompleted } from '../actions/classifier'
 import { isEmpty } from 'ramda'
@@ -48,6 +49,7 @@ export class SwipeClassifier extends React.Component {
     this.setQuestionVisibility = this.setQuestionVisibility.bind(this)
     this.state = {
       isQuestionVisible: true,
+      showFullSize: false,
     }
     this.props.setIsFetching(true)
     this.props.startNewClassification(this.props.workflowID)
@@ -73,6 +75,7 @@ export class SwipeClassifier extends React.Component {
     const renderClassifierOrTutorial = () => {
       const key = this.props.workflow.first_task //always just one task
       const task = this.props.workflow.tasks[key]
+      const allowPanAndZoom = this.props.workflow.configuration.pan_and_zoom
 
       const backSubject =
         <SwipeSubject
@@ -95,11 +98,12 @@ export class SwipeClassifier extends React.Component {
           </View>
         </View>
 
-      const swipeableSubject =
-        <Swipeable
-          key={this.props.subject.id}
-          workflowID={this.props.workflowID}
-        />
+        const swipeableSubject =
+          <Swipeable
+            key={this.props.subject.id}
+            workflowID={this.props.workflowID}
+            showFullSize={() => this.setState({showFullSize: true})}
+          />
 
       const tutorial =
         <Tutorial
@@ -122,6 +126,11 @@ export class SwipeClassifier extends React.Component {
           </ClassificationPanel>
           { this.state.isQuestionVisible ? swipeableSubject : null }
           { this.state.isQuestionVisible ? <SwipeTabs guide={this.props.guide} /> : null }
+          <FullScreenImage
+            source={{uri: this.props.subject.display.src}}
+            isVisible={this.state.showFullSize}
+            allowPanAndZoom={allowPanAndZoom}
+            handlePress={() => this.setState({ showFullSize: false })} />
         </View>
 
       //needsTutorial is for the first time a guest or user visits this project
@@ -151,9 +160,13 @@ SwipeClassifier.propTypes = {
   workflow: React.PropTypes.shape({
     first_task: React.PropTypes.string,
     tasks: React.PropTypes.object,
+    configuration: React.PropTypes.object,
   }),
   subject: React.PropTypes.shape({
     id: React.PropTypes.string,
+    display: React.PropTypes.shape({
+      src: React.PropTypes.string
+    })
   }),
   nextSubject: React.PropTypes.shape({
     id: React.PropTypes.string

--- a/src/components/Swipeable.js
+++ b/src/components/Swipeable.js
@@ -3,6 +3,7 @@ import {
   Animated,
   PanResponder,
   Platform,
+  TouchableOpacity,
   View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
@@ -132,7 +133,10 @@ export class Swipeable extends Component {
             style={[styles.imageContainer, animatedCardStyles, swipeableSize]}
             {...this._panResponder.panHandlers}>
 
-            <View style={swipeableSize}>
+            <TouchableOpacity
+              activeOpacity={0.8}
+              style={swipeableSize}
+              onPress={this.props.showFullSize}>
               <SwipeSubject
                 inFront={true}
                 subject={this.props.subject}
@@ -149,7 +153,7 @@ export class Swipeable extends Component {
               <Animated.View style={[styles.overlayContainer, rightOverlayTextStyle, imageSizeStyle]}>
                 <StyledText additionalStyles={[styles.answerOverlayText]} text={ answers[1].label } />
               </Animated.View>
-            </View>
+            </TouchableOpacity>
           </Animated.View>
         </View>
       </View>
@@ -216,6 +220,7 @@ Swipeable.propTypes = {
   saveAnnotation: React.PropTypes.func,
   questionContainerHeight: React.PropTypes.number,
   setNextSubject: React.PropTypes.func,
+  showFullSize: React.PropTypes.func,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Swipeable)

--- a/src/components/ZoomableImage.js
+++ b/src/components/ZoomableImage.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import {
+  Dimensions,
+  Image
+} from 'react-native'
+import ImageZoom from 'react-native-image-pan-zoom'
+
+class ZoomableImage extends React.Component {
+  constructor(props) {
+    super(props)
+     this.state = {
+       height: 0,
+       width: 0
+     }
+  }
+
+  componentWillMount() {
+    const deviceWidth = Dimensions.get('window').width
+    const deviceHeight = Dimensions.get('window').height
+
+    Image.getSize(this.props.source.uri, (width, height) => {
+      const aspectRatio = Math.min(deviceWidth / width, deviceHeight / height)
+      const resizedHeight = height * aspectRatio
+      const resizedWidth = width * aspectRatio
+      this.setState({ height: resizedHeight, width: resizedWidth })
+    })
+  }
+
+  render() {
+    return (
+      <ImageZoom
+        cropWidth={Dimensions.get('window').width}
+        cropHeight={Dimensions.get('window').height}
+        imageWidth={this.state.width}
+        imageHeight={this.state.height}
+        panToMove={ this.props.allowPanAndZoom }
+        pinchToZoom={ this.props.allowPanAndZoom }
+        onLongPress={this.props.handlePress}
+        longPressTime={ 300 }>
+        <Image
+          source={ this.props.source }
+          style={{width: this.state.width, height: this.state.height}} />
+      </ImageZoom>
+    )
+  }
+}
+
+
+ZoomableImage.propTypes = {
+  source: React.PropTypes.shape({
+    uri: React.PropTypes.string,
+  }),
+  handlePress: React.PropTypes.func,
+  imageWidth: React.PropTypes.number,
+  imageHeight: React.PropTypes.number,
+  allowPanAndZoom: React.PropTypes.bool,
+}
+
+export default ZoomableImage

--- a/src/components/__tests__/FullScreenImage-test.js
+++ b/src/components/__tests__/FullScreenImage-test.js
@@ -1,0 +1,32 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import FullScreenImage from '../FullScreenImage'
+
+const imageSource = {
+  uri: 'https://placekitten.com/200/300'
+}
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <FullScreenImage
+      source={imageSource}
+      handlePress={jest.fn}
+      isVisible={true}
+      allowPanAndZoom={true}
+    />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders hidden correctly', () => {
+  const tree = renderer.create(
+    <FullScreenImage
+      source={imageSource}
+      handlePress={jest.fn}
+      isVisible={false}
+      allowPanAndZoom={true}
+    />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/SwipeClassifier-test.js
+++ b/src/components/__tests__/SwipeClassifier-test.js
@@ -18,6 +18,16 @@ const workflow = {
     T0: {
       question: 'What was that?'
     }
+  },
+  configuration: {
+    pan_and_zoom: true
+  }
+}
+
+const subject = {
+  id: '23432432',
+  display: {
+    src: 'blah.jpg'
   }
 }
 
@@ -38,7 +48,7 @@ it('renders correctly', () => {
       project={project}
       workflow={workflow}
       workflowID={'1'}
-      subject={{id: '23432432'}}
+      subject={subject}
       subjectSizes={subjectSizes}
       seenThisSession={seenThisSession} />
   ).toJSON()
@@ -54,7 +64,7 @@ it('renders spinner if fetching', () => {
       project={project}
       workflow={workflow}
       workflowID={'1'}
-      subject={{id: '23432432'}}
+      subject={subject}
       subjectSizes={subjectSizes}
       seenThisSession={seenThisSession} />
   ).toJSON()
@@ -71,7 +81,7 @@ it('renders tutorial if needed', () => {
       project={project}
       workflow={workflow}
       workflowID={'1'}
-      subject={{id: '23432432'}}
+      subject={subject}
       subjectSizes={subjectSizes}
       seenThisSession={seenThisSession} />
   ).toJSON()

--- a/src/components/__tests__/ZoomableImage-test.js
+++ b/src/components/__tests__/ZoomableImage-test.js
@@ -1,0 +1,21 @@
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ZoomableImage from '../ZoomableImage'
+
+const imageSource = {
+  uri: 'https://placekitten.com/200/300'
+}
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <ZoomableImage
+      source={imageSource}
+      handlePress={jest.fn}
+      imageWidth={100}
+      imageHeight={200}
+      allowPanAndZoom={true}
+    />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/FullScreenImage-test.js.snap
+++ b/src/components/__tests__/__snapshots__/FullScreenImage-test.js.snap
@@ -1,0 +1,271 @@
+exports[`test renders correctly 1`] = `
+<Modal
+  animationType="fade"
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={true}>
+  <View
+    style={undefined}>
+    <View
+      onMoveShouldSetResponder={[Function]}
+      onMoveShouldSetResponderCapture={[Function]}
+      onResponderEnd={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderReject={[Function]}
+      onResponderRelease={[Function]}
+      onResponderStart={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      onStartShouldSetResponderCapture={[Function]}
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "justifyContent": "center",
+            "overflow": "hidden",
+          },
+          Object {
+            "height": 667,
+            "width": 375,
+          },
+        ]
+      }>
+      <View
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": 0,
+              },
+            ],
+          }
+        }>
+        <View
+          onLayout={[Function]}
+          style={
+            Object {
+              "height": 0,
+              "width": 0,
+            }
+          }>
+          <Image
+            source={
+              Object {
+                "uri": "https://placekitten.com/200/300",
+              }
+            }
+            style={
+              Object {
+                "height": 0,
+                "width": 0,
+              }
+            } />
+        </View>
+      </View>
+    </View>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            Array [
+              undefined,
+            ],
+          ]
+        }>
+        You can zoom into this image
+      </Text>
+    </View>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+  </View>
+</Modal>
+`;
+
+exports[`test renders hidden correctly 1`] = `
+<Modal
+  animationType="fade"
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={false}>
+  <View
+    style={undefined}>
+    <View
+      onMoveShouldSetResponder={[Function]}
+      onMoveShouldSetResponderCapture={[Function]}
+      onResponderEnd={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderReject={[Function]}
+      onResponderRelease={[Function]}
+      onResponderStart={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      onStartShouldSetResponderCapture={[Function]}
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "justifyContent": "center",
+            "overflow": "hidden",
+          },
+          Object {
+            "height": 667,
+            "width": 375,
+          },
+        ]
+      }>
+      <View
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": 0,
+              },
+            ],
+          }
+        }>
+        <View
+          onLayout={[Function]}
+          style={
+            Object {
+              "height": 0,
+              "width": 0,
+            }
+          }>
+          <Image
+            source={
+              Object {
+                "uri": "https://placekitten.com/200/300",
+              }
+            }
+            style={
+              Object {
+                "height": 0,
+                "width": 0,
+              }
+            } />
+        </View>
+      </View>
+    </View>
+    <View
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            undefined,
+            Array [
+              undefined,
+            ],
+          ]
+        }>
+        You can zoom into this image
+      </Text>
+    </View>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      onPress={[Function]}
+      style={undefined}>
+      <Text
+        accessible={true}
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": undefined,
+              "fontFamily": "FontAwesome",
+              "fontSize": 12,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }>
+        
+      </Text>
+    </TouchableOpacity>
+  </View>
+</Modal>
+`;

--- a/src/components/__tests__/__snapshots__/SwipeClassifier-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SwipeClassifier-test.js.snap
@@ -88,9 +88,143 @@ exports[`test renders correctly 1`] = `
     </View>
   </View>
   <Swipeable
+    showFullSize={[Function]}
     workflowID="1" />
   <SwipeTabs
     guide={undefined} />
+  <Modal
+    animationType="fade"
+    onRequestClose={[Function]}
+    transparent={true}
+    visible={false}>
+    <View
+      style={undefined}>
+      <View
+        onMoveShouldSetResponder={[Function]}
+        onMoveShouldSetResponderCapture={[Function]}
+        onResponderEnd={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderReject={[Function]}
+        onResponderRelease={[Function]}
+        onResponderStart={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onStartShouldSetResponderCapture={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "justifyContent": "center",
+              "overflow": "hidden",
+            },
+            Object {
+              "height": 667,
+              "width": 375,
+            },
+          ]
+        }>
+        <View
+          style={
+            Object {
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+                Object {
+                  "translateX": 0,
+                },
+                Object {
+                  "translateY": 0,
+                },
+              ],
+            }
+          }>
+          <View
+            onLayout={[Function]}
+            style={
+              Object {
+                "height": 0,
+                "width": 0,
+              }
+            }>
+            <Image
+              source={
+                Object {
+                  "uri": "blah.jpg",
+                }
+              }
+              style={
+                Object {
+                  "height": 0,
+                  "width": 0,
+                }
+              } />
+          </View>
+        </View>
+      </View>
+      <View
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontFamily": "FontAwesome",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }>
+          
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              undefined,
+              Array [
+                undefined,
+              ],
+            ]
+          }>
+          You can zoom into this image
+        </Text>
+      </View>
+      <TouchableOpacity
+        activeOpacity={0.5}
+        onPress={[Function]}
+        style={undefined}>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontFamily": "FontAwesome",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }>
+          
+        </Text>
+      </TouchableOpacity>
+    </View>
+  </Modal>
 </View>
 `;
 

--- a/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
@@ -40,7 +40,9 @@ exports[`test renders correctly 1`] = `
           "width": 100,
         }
       }>
-      <View
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={undefined}
         style={
           Object {
             "height": 110,
@@ -126,7 +128,7 @@ exports[`test renders correctly 1`] = `
             Yes
           </Text>
         </View>
-      </View>
+      </TouchableOpacity>
     </View>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/ZoomableImage-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ZoomableImage-test.js.snap
@@ -1,0 +1,68 @@
+exports[`test renders correctly 1`] = `
+<View
+  onMoveShouldSetResponder={[Function]}
+  onMoveShouldSetResponderCapture={[Function]}
+  onResponderEnd={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderReject={[Function]}
+  onResponderRelease={[Function]}
+  onResponderStart={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  onStartShouldSetResponderCapture={[Function]}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "justifyContent": "center",
+        "overflow": "hidden",
+      },
+      Object {
+        "height": 667,
+        "width": 375,
+      },
+    ]
+  }>
+  <View
+    style={
+      Object {
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+          Object {
+            "translateX": 0,
+          },
+          Object {
+            "translateY": 0,
+          },
+        ],
+      }
+    }>
+    <View
+      onLayout={[Function]}
+      style={
+        Object {
+          "height": 0,
+          "width": 0,
+        }
+      }>
+      <Image
+        source={
+          Object {
+            "uri": "https://placekitten.com/200/300",
+          }
+        }
+        style={
+          Object {
+            "height": 0,
+            "width": 0,
+          }
+        } />
+    </View>
+  </View>
+</View>
+`;


### PR DESCRIPTION
Adds the ability to tap an image in the classifier and see it displayed full screen.  If the pan and zoom is enabled on the workflow, it will allow the user to pinch to zoom.
  *  Also adds new npm package for creating zoomable images
  *  The ZoomableImage component can be reuseable elsewhere if desired

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

