### PR TITLE
Fix navigation errors

### DIFF
--- a/src/components/SwipeClassifier.js
+++ b/src/components/SwipeClassifier.js
@@ -131,7 +131,7 @@ export class SwipeClassifier extends React.Component {
     }
 
     return (
-      this.props.isFetching ? <OverlaySpinner overrideVisibility={this.props.isFetching} /> : renderClassifierOrTutorial()
+      this.props.isFetching || isEmpty(this.props.workflow) ? <OverlaySpinner overrideVisibility={this.props.isFetching} /> : renderClassifierOrTutorial()
     )
   }
 }


### PR DESCRIPTION
Fixes #119 

After merging the classifier PR my solution no longer was feasible.  This will prevent navigation errors when moving from one project to another by displaying the spinner until the workflow has been loaded.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

