### PR TITLE
Add Unlinked Tasks

### DIFF
--- a/src/actions/classifier.js
+++ b/src/actions/classifier.js
@@ -1,6 +1,6 @@
 import apiClient from 'panoptes-client/lib/api-client'
 import { forEach, isEmpty, isNil, map, remove, toPairs } from 'ramda'
-import { addState, setState } from '../actions/index'
+import { addState, removeState, setState } from '../actions/index'
 import { Actions } from 'react-native-router-flux'
 import { Alert, Platform } from 'react-native'
 import { getAuthUser } from '../actions/auth'
@@ -69,6 +69,13 @@ export function saveAnnotation(task, value) {
   return (dispatch, getState) => {
     const workflowID = getState().classifier.currentWorkflowID
     dispatch(setState(`classifier.annotations.${workflowID}.${task}`, value))
+  }
+}
+
+export function removeAnnotationValue(task, value) {
+  return (dispatch, getState) => {
+    const workflowID = getState().classifier.currentWorkflowID
+    dispatch(removeState(`classifier.annotations.${workflowID}.${task}`, value))
   }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,6 @@
 export const SET_STATE = 'SET_STATE'
 export const ADD_STATE = 'ADD_STATE'
+export const REMOVE_STATE = 'REMOVE_STATE'
 export const SET_USER = 'SET_USER'
 export const SET_ERROR = 'SET_ERROR'
 export const SET_IS_FETCHING = 'SET_IS_FETCHING'
@@ -23,6 +24,10 @@ export function setState(stateKey, value) {
 
 export function addState(stateKey, value) {
   return { type: ADD_STATE, stateKey, value }
+}
+
+export function removeState(stateKey, value) {
+  return { type: REMOVE_STATE, stateKey, value }
 }
 
 export function setUser(user) {

--- a/src/components/Swipeable.js
+++ b/src/components/Swipeable.js
@@ -112,7 +112,7 @@ export class Swipeable extends Component {
     let rightOverlayTextStyle = {opacity: opacityRightText}
 
     return (
-      <View style={[styles.container, {top: toTop + this.props.questionContainerHeight}]}>
+      <View style={[styles.container, {top: toTop + this.props.questionContainerHeight, height: this.props.subjectSizes.resizedHeight + 40}]}>
         <View style={styles.subjectContainer}>
           <Animated.View
             style={[styles.imageContainer, animatedCardStyles, swipeableSize]}
@@ -151,7 +151,6 @@ const styles = EStyleSheet.create({
     position: 'absolute',
     right: 0,
     left: 0,
-    bottom: 0,
     backgroundColor: 'transparent',
     flex: 1,
     paddingVertical: 10,

--- a/src/components/UnlinkedTask.js
+++ b/src/components/UnlinkedTask.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import {
+  Switch,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import EStyleSheet from 'react-native-extended-stylesheet'
+import StyledText from './StyledText'
+import { addIndex, contains, map } from 'ramda'
+import theme from '../theme'
+
+const UnlinkedTask = (props) => {
+  const annotationValues = props.annotation || []
+
+  const renderUnlinkedTask = ( answer, idx ) => {
+    return (
+      <View key={ idx } style={styles.rowContainer}>
+        <Switch
+          value={contains(idx, annotationValues)}
+          style={styles.switchComponent}
+          onTintColor={theme.headerColor}
+          onValueChange={()=>props.onAnswered(props.unlinkedTaskKey, idx)}
+        />
+
+        <TouchableOpacity
+          style={styles.answerContainer}
+          onPress={ ()=>props.onAnswered(props.unlinkedTaskKey, idx) }
+          activeOpacity={0.5}>
+          <StyledText additionalStyles={[styles.answer]} text={ answer.label } />
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      { addIndex(map)(
+        (answer, idx) => {
+          return renderUnlinkedTask(answer, idx)
+        },
+        props.unlinkedTask.answers
+      ) }
+    </View>
+  )
+}
+
+const styles = EStyleSheet.create({
+  container: {
+    alignSelf: 'flex-start',
+    margin: 20
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start'
+  },
+  switchComponent: {
+    margin: 3
+  },
+  answerContainer: {
+  },
+  answer: {
+    alignSelf: 'center',
+    flexWrap: 'wrap',
+    textAlign: 'center',
+    fontSize: 13,
+  }
+});
+
+UnlinkedTask.propTypes = {
+  unlinkedTask: React.PropTypes.object.isRequired,
+  onAnswered: React.PropTypes.func.isRequired,
+  annotation: React.PropTypes.array,
+  unlinkedTaskKey: React.PropTypes.string.isRequired,
+}
+
+export default UnlinkedTask

--- a/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
@@ -4,6 +4,7 @@ exports[`test renders correctly 1`] = `
     Array [
       undefined,
       Object {
+        "height": 140,
         "top": NaN,
       },
     ]

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,4 @@
-import { append, merge, lensPath, set, view } from 'ramda'
+import { append, equals, lensPath, merge, reject, set, view } from 'ramda'
 
 export const InitialState = {
   user: {},
@@ -48,6 +48,13 @@ export default function(state=InitialState, action) {
           action.value, view(lensPath(action.stateKey.split('.')),
           state)
         ), state)
+    case 'REMOVE_STATE':
+      return set(lensPath(action.stateKey.split('.')),
+        reject(
+          equals(action.value), view(lensPath(action.stateKey.split('.')),
+          state)
+        ), state)
+
     case 'SET_USER':
       return merge(state, {
         user: action.user


### PR DESCRIPTION
Add Unlinked Tasks/Shortcuts and ability to save additional annotations for the unlinked task and the ability to remove annotations in case a the switch is "unchecked".  This will allow more than two unlinked tasks, but other checks should prevent a workflow with more than two from being swipe eligible, due to screen size.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

