### PR TITLE
Don't Initiate Tutorial if Non-existent 

### DIFF
--- a/src/components/SwipeClassifier.js
+++ b/src/components/SwipeClassifier.js
@@ -185,7 +185,7 @@ export class SwipeClassifier extends React.Component {
 
       //needsTutorial is for the first time a guest or user visits this project
       return (
-        this.props.needsTutorial ? tutorial : classificationPanel
+        this.props.needsTutorial && !isEmpty(this.props.tutorial) ? tutorial : classificationPanel
       )
     }
 


### PR DESCRIPTION
Describe your changes.
Snapshots at Sea was not opening in the native app's swipe classifier. This turned out to be an issue because the `SwipeClassifier` component was trying to initialize a `Tutorial` component when the project did not have a tutorial.

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?

