### PR TITLE
Change Swipe Tag Location

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -168,7 +168,7 @@ export function fetchProjects(parms, stateKey) {
 
 function tagSwipeFriendly(workflows) {
   return map((workflow) => {
-    workflow.swipe_verified = !!workflow.configuration.swipe_enabled && isValidSwipeWorkflow(workflow)
+    workflow.swipe_verified = !!workflow.configuration.swipe_enabled || !!workflow.swipe_enabled && isValidSwipeWorkflow(workflow)
     return workflow
   }, workflows)
 }


### PR DESCRIPTION
Describe your changes.
This PR changes the location of the swipe_classifier tag with the discussion made in [this](https://github.com/zooniverse/Panoptes/issues/2432) backend issue.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

