### PR TITLE
Restyle UnlinkedTask Component

### DIFF
--- a/src/components/UnlinkedTask.js
+++ b/src/components/UnlinkedTask.js
@@ -47,7 +47,7 @@ const UnlinkedTask = (props) => {
 const styles = EStyleSheet.create({
   container: {
     alignSelf: 'flex-start',
-    margin: 10,
+    margin: 15,
     position: 'absolute',
     bottom: 65
   },

--- a/src/components/UnlinkedTask.js
+++ b/src/components/UnlinkedTask.js
@@ -47,23 +47,25 @@ const UnlinkedTask = (props) => {
 const styles = EStyleSheet.create({
   container: {
     alignSelf: 'flex-start',
-    margin: 20
+    margin: 10,
+    position: 'absolute',
+    bottom: 65
   },
   rowContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'flex-start'
+    width: '85%',
   },
   switchComponent: {
     margin: 3
   },
   answerContainer: {
+    flex: 1
   },
   answer: {
-    alignSelf: 'center',
     flexWrap: 'wrap',
-    textAlign: 'center',
-    fontSize: 13,
+    margin: 3,
+    fontSize: 10,
   }
 });
 


### PR DESCRIPTION
There's an issue with the way unlinked tasks/shortcuts are displayed in the mobile app (see images attached). This clears up the issue and should be merged in order to be live by the Dec. 13 launch of Floating Forests (with a couple days needed for Apple to approve the update).

Describe your changes.
Changed styles for the UnlinkedTask component.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

![image uploaded from ios](https://user-images.githubusercontent.com/14099077/33739831-2ce035ee-db64-11e7-8190-26fcfca56d89.png)
![image1](https://user-images.githubusercontent.com/14099077/33739834-2ed7a922-db64-11e7-8a4f-606b4cd3ee30.png)


