### PR TITLE
Issue151 - Use mobile_friendly workflow attribute

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -145,7 +145,7 @@ export function fetchProjects(parms, stateKey) {
             const promise = apiClient.type('avatars').get(project.links.avatar.id).then((avatar) => {
               project.avatar_src = avatar.src
             }).then(() => {
-              return project.get('workflows', {page_size: 100, active: true})
+              return project.get('workflows', {mobile_friendly: true, active: true})
             }).then((workflows) => {
               project.workflows = tagSwipeFriendly(workflows)
               return dispatch(addState(stateKey, project))
@@ -168,7 +168,7 @@ export function fetchProjects(parms, stateKey) {
 
 function tagSwipeFriendly(workflows) {
   return map((workflow) => {
-    workflow.swipe_verified = !!workflow.configuration.swipe_enabled && isValidSwipeWorkflow(workflow)
+    workflow.swipe_verified = workflow.mobile_friendly && isValidSwipeWorkflow(workflow)
     return workflow
   }, workflows)
 }


### PR DESCRIPTION
Fixes #151.

Describe your changes.
Instead of pulling the top 100 projects from a page, we are pulling only the ones that are `mobile_friendly`.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

