### PR TITLE
144: Fix Header

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -71,7 +71,6 @@ class About extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 70,
   },
   header: {
     marginBottom: 5,

--- a/src/components/ClassificationPanel.js
+++ b/src/components/ClassificationPanel.js
@@ -43,8 +43,6 @@ const styles = EStyleSheet.create({
   container: {
     backgroundColor: '$lightestGrey',
     flex: 1,
-    marginTop: 60,
-    paddingTop: topPadding,
     paddingBottom: 0,
   },
   panelContainer: {

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,9 +13,7 @@ import Icon from 'react-native-vector-icons/FontAwesome'
 import PropTypes from 'prop-types';
 import UserAvatar from './UserAvatar'
 import CircleRibbon from './CircleRibbon'
-
-const topPadding = (Platform.OS === 'ios') ? 22 : 10
-const height = 48 + topPadding
+import { $headerColor } from '../theme.js'
 
 const mapStateToProps = (state) => ({
   user: state.user,
@@ -41,8 +39,6 @@ export class NavBar extends Component {
   }
 
   render() {
-    const containerHeight = (this.props.showAvatar ? height + 70 : height )
-    const logo = <Image source={require('../../images/logo.png')} style={styles.logo} />
     const userAvatar = ( this.props.user.avatar === undefined ? null : this.props.user.avatar.src )
 
     const avatar =
@@ -51,97 +47,124 @@ export class NavBar extends Component {
         <CircleRibbon />
       </View>
 
-    const title =
-      <Text style={styles.title}>
-        { this.props.title }
+    const CenterContainer = ({shouldShowTitle, shouldShowLogo}) => {
+      let centerElement = null;
+      if (shouldShowTitle){
+        centerElement = 
+          <Text style={styles.title} numberOfLines={1}>
+            { this.props.title }
       </Text>
+      } else if (shouldShowLogo) {
+        centerElement = <Image source={require('../../images/logo.png')} style={styles.logo} />
+      }
 
-    const back =
-      <TouchableOpacity
-        activeOpacity={0.5}
-        onPress={this.handleOnBack}
-        style={styles.leftIcon}>
-        <Icon name="angle-left" style={styles.icon} />
-      </TouchableOpacity>
+      return (
+        <View style={styles.centerContainer}>
+          {centerElement}
+        </View>
+      );
+    };
 
-    const drawer =
-      <TouchableOpacity
-        activeOpacity={0.5}
-        onPress={this.handleSideDrawer.bind(this)}
-        style={styles.rightIcon}>
-        <Icon name="bars" style={[styles.icon, styles.iconBar]} />
+    const LeftContainer = ({isActive}) => {
+      const colorStyle = isActive ? {} : styles.disabledIcon
+      return (
+        <View>
+          <TouchableOpacity
+            activeOpacity={0.5}
+            onPress={this.handleOnBack}
+            disabled={!isActive}
+          >
+            <Icon name="angle-left" style={[styles.leftIcon, styles.icon, colorStyle]} />
+          </TouchableOpacity>
+        </View>
+      )
+    }
+
+    const RightContainer = ({isActive}) => {
+      const colorStyle = isActive ? {} : styles.disabledIcon
+      return (
+        <View>
+          <TouchableOpacity
+            activeOpacity={0.5}
+            onPress={this.handleSideDrawer.bind(this)}
+            disabled={!isActive}
+          >
+          <Icon name="bars" style={[styles.icon, styles.rightIcon, colorStyle]} />
       </TouchableOpacity>
+        </View>
+      );
+    }
 
     return (
-      <View style={[styles.navBarContainer, {height: containerHeight}]}>
+      <View style={[styles.navBarContainer]}>
         <View style={styles.navBar}>
-          { this.props.showBack ? back : null }
-          { this.props.title ? title : null }
-          { this.props.showLogo ? logo : null }
-          { this.props.showDrawer ? drawer : null }
+          <LeftContainer isActive={this.props.showBack} />
+          <CenterContainer shouldShowTitle={this.props.title} shouldShowLogo={this.props.showLogo} />
+          <RightContainer isActive={this.props.showDrawer} />
         </View>
-        { this.props.showAvatar ? avatar : null }
+        <View>
+          { this.props.showAvatar ? avatar : null }
+        </View>
       </View>
     );
   }
 }
 
+const navBarHeight = (Platform.OS === 'ios') ? 74 : 62
+const navBarPadding = (Platform.OS === 'ios') ? 36 : 24
+
 const styles = EStyleSheet.create({
   navBarContainer: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
+    flexDirection: 'column',
+    height: navBarHeight
   },
   navBar: {
     backgroundColor: '$headerColor',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: height,
-    paddingBottom: 10,
-    paddingTop: topPadding,
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingTop: navBarPadding,
+  },
+  centerContainer: {
+    flex: 1,
   },
   leftIcon: {
-    position: 'absolute',
-    left: 5,
-    top: topPadding - 2
+    paddingLeft: 25,
+    paddingRight: 15
   },
   rightIcon: {
-    position: 'absolute',
-    right: 10,
-    top: topPadding,
+    paddingLeft: 15,
+    paddingRight: 25,
+    paddingTop: 5,
+    alignContent: 'flex-end',
+    fontSize: 24
   },
   icon: {
     backgroundColor: '$transparent',
     color: '$textColor',
     fontSize: 30,
-    width: 40,
-    padding: 10
-  },
-  iconBar: {
-    fontSize: 24
   },
   title: {
     color: '$textColor',
     fontFamily: 'OpenSans-Semibold',
     fontSize: 20,
-    lineHeight: 30
+    lineHeight: 30,
+    textAlign: 'center',
   },
   logo: {
-    width: '40%',
-    height: 50,
+    flex: 1,
+    width: '70%',
     resizeMode: 'contain',
-    position: 'relative',
-    top: 5
+    alignSelf: 'center'
   },
   userAvatarContainer: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'absolute',
-    top: topPadding + 20,
-    left: 60,
-    right: 60,
+    marginTop: -25,
+    alignSelf: 'center',
+    alignItems: 'center'
+  },
+  disabledIcon: {
+    color: '$transparent'
   }
 })
 

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,7 +13,6 @@ import Icon from 'react-native-vector-icons/FontAwesome'
 import PropTypes from 'prop-types';
 import UserAvatar from './UserAvatar'
 import CircleRibbon from './CircleRibbon'
-import { $headerColor } from '../theme.js'
 
 const mapStateToProps = (state) => ({
   user: state.user,

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -52,7 +52,7 @@ export class NavBar extends Component {
         centerElement = 
           <Text style={styles.title} numberOfLines={1}>
             { this.props.title }
-      </Text>
+        </Text>
       } else if (shouldShowLogo) {
         centerElement = <Image source={require('../../images/logo.png')} style={styles.logo} />
       }
@@ -73,7 +73,7 @@ export class NavBar extends Component {
             onPress={this.handleOnBack}
             disabled={!isActive}
           >
-            <Icon name="angle-left" style={[styles.leftIcon, styles.icon, colorStyle]} />
+            <Icon name="chevron-left" style={[styles.leftIcon, styles.icon, colorStyle]} />
           </TouchableOpacity>
         </View>
       )
@@ -129,19 +129,18 @@ const styles = EStyleSheet.create({
   },
   leftIcon: {
     paddingLeft: 25,
-    paddingRight: 15
+    paddingRight: 15,
+    fontSize: 26
   },
   rightIcon: {
     paddingLeft: 15,
     paddingRight: 25,
-    paddingTop: 5,
     alignContent: 'flex-end',
-    fontSize: 24
+    fontSize: 26
   },
   icon: {
     backgroundColor: '$transparent',
     color: '$textColor',
-    fontSize: 30,
   },
   title: {
     color: '$textColor',

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -145,10 +145,10 @@ const styles = EStyleSheet.create({
   subNavContainer: {
     borderBottomColor: '$lightGrey',
     borderBottomWidth: StyleSheet.hairlineWidth,
-    paddingTop: 136 + topPadding,
+    paddingTop: 64 + topPadding,
     alignItems: 'center',
     justifyContent: 'flex-start',
-    height: 184 + topPadding
+    height: 112 + topPadding
   },
   userName: {
     color: '$darkTextColor',

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -91,7 +91,6 @@ export class ProjectList extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 60,
     backgroundColor: '$lightGreyBackground'
   },
   innerContainer: {

--- a/src/components/PublicationFilter.js
+++ b/src/components/PublicationFilter.js
@@ -94,7 +94,6 @@ class PublicationFilter extends React.Component {
 }
 
 //the following are required for absolutely positioned items on Android
-const topPadding = (Platform.OS === 'ios') ? 70 : 58
 const filterWidth = 150
 const itemHeight = 40
 const menuHeight = itemHeight * (length(keys(PUBLICATIONS)) + 1)
@@ -107,15 +106,10 @@ const styles = EStyleSheet.create({
   container: {
     position: 'absolute',
     flex: 1,
-    top: topPadding,
     right: 0,
     left: 0,
     width: '100%',
     height: itemHeight
-  },
-  fullHeightContainer: {
-    bottom: 0,
-    height: '100%'
   },
   dropdownViewContainer: {
     position: 'absolute',

--- a/src/components/PublicationList.js
+++ b/src/components/PublicationList.js
@@ -125,10 +125,10 @@ export class PublicationList extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 110,
+    paddingTop: 40,
   },
   listStyle: {
-    paddingTop: 90
+    paddingTop: 20
   },
   messageContainer: {
     padding: 15,

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -195,7 +195,6 @@ export class Register extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 70,
   },
   registerContainer: {
     flex: 1,

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -150,7 +150,6 @@ export class Settings extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 60,
     paddingLeft: 10,
     paddingRight: 10
   },
@@ -170,7 +169,6 @@ const styles = EStyleSheet.create({
     marginRight: 10,
   },
   section: {
-    marginTop: 5,
     marginBottom: 5,
   }
 });

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -19,8 +19,6 @@ import OverlaySpinner from './OverlaySpinner'
 import StyledText from './StyledText'
 import { Actions } from 'react-native-router-flux'
 
-const topPadding = (Platform.OS === 'ios') ? 72 : 60
-
 const mapStateToProps = (state) => ({
   isFetching: state.main.isFetching,
   errorMessage: state.main.errorMessage,
@@ -144,7 +142,6 @@ const styles = EStyleSheet.create({
   },
   container: {
     flex: 1,
-    paddingTop: topPadding,
   },
   signInContainer: {
     backgroundColor: 'transparent',

--- a/src/components/Swipeable.js
+++ b/src/components/Swipeable.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 
 //needs to be absolutely positioned below the question, otherwise it covers up
 //everything above and prevents it from being touchable
-const toTop = (Platform.OS === 'ios') ? 135 : 125
+const toTop = (Platform.OS === 'ios') ? 65 : 55
 const SWIPE_THRESHOLD = 90
 const leftOverlayColor = theme.$swipeLeft
 const rightOverlayColor = theme.$swipeRight

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -129,7 +129,6 @@ const styles = EStyleSheet.create({
   },
   firstTutorialContainer: {
     flex: 1,
-    marginTop: 60,
     paddingTop: topPadding,
     paddingBottom: 0,
   },
@@ -187,7 +186,7 @@ const styles = EStyleSheet.create({
   tutorialHeader: {
     fontSize: 20,
     marginHorizontal: 30,
-    marginTop: 80,
+    marginTop: 10,
     marginBottom: 0,
     paddingTop: topPadding,
     paddingBottom: 0,

--- a/src/components/ZooWebView.js
+++ b/src/components/ZooWebView.js
@@ -152,7 +152,6 @@ class ZooWebView extends React.Component {
 const styles = EStyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: (Platform.OS === 'ios') ? 70 : 58,
   },
 })
 

--- a/src/components/__tests__/__snapshots__/NavBar-test.js.snap
+++ b/src/components/__tests__/__snapshots__/NavBar-test.js.snap
@@ -5,66 +5,123 @@ exports[`renders correctly with defaults 1`] = `
   style={
     Array [
       undefined,
-      Object {
-        "height": 70,
-      },
     ]
   }
 >
   <View
     style={undefined}
   >
-    <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      collapsable={undefined}
-      hasTVPreferredFocus={undefined}
-      hitSlop={undefined}
-      isTVSelectable={true}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "opacity": 1,
-        }
-      }
-      testID={undefined}
-      tvParallaxProperties={undefined}
-    >
-      <Text
+    <View>
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
         accessible={true}
-        allowFontScaling={false}
-        ellipsizeMode="tail"
+        collapsable={undefined}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {
-              "color": undefined,
-              "fontSize": 12,
-            },
-            Array [
-              undefined,
-              undefined,
-            ],
-            Object {
-              "fontFamily": "FontAwesome",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-          ]
+          Object {
+            "opacity": 1,
+          }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
-        
-      </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 12,
+              },
+              Array [
+                undefined,
+                undefined,
+                undefined,
+              ],
+              Object {
+                "fontFamily": "FontAwesome",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <View
+      style={undefined}
+    />
+    <View>
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 12,
+              },
+              Array [
+                undefined,
+                undefined,
+                Object {},
+              ],
+              Object {
+                "fontFamily": "FontAwesome",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
     </View>
   </View>
+  <View />
 </View>
 `;
 
@@ -73,73 +130,132 @@ exports[`renders correctly with title 1`] = `
   style={
     Array [
       undefined,
-      Object {
-        "height": 70,
-      },
     ]
   }
 >
   <View
     style={undefined}
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={undefined}
-    >
-      OHai
-    </Text>
-    <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      collapsable={undefined}
-      hasTVPreferredFocus={undefined}
-      hitSlop={undefined}
-      isTVSelectable={true}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "opacity": 1,
+    <View>
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
         }
-      }
-      testID={undefined}
-      tvParallaxProperties={undefined}
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 12,
+              },
+              Array [
+                undefined,
+                undefined,
+                undefined,
+              ],
+              Object {
+                "fontFamily": "FontAwesome",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <View
+      style={undefined}
     >
       <Text
         accessible={true}
-        allowFontScaling={false}
+        allowFontScaling={true}
         ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": undefined,
-              "fontSize": 12,
-            },
-            Array [
-              undefined,
-              undefined,
-            ],
-            Object {
-              "fontFamily": "FontAwesome",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-          ]
-        }
+        numberOfLines={1}
+        style={undefined}
       >
-        
+        OHai
       </Text>
     </View>
+    <View>
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 12,
+              },
+              Array [
+                undefined,
+                undefined,
+                Object {},
+              ],
+              Object {
+                "fontFamily": "FontAwesome",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
   </View>
+  <View />
 </View>
 `;

--- a/src/components/__tests__/__snapshots__/NavBar-test.js.snap
+++ b/src/components/__tests__/__snapshots__/NavBar-test.js.snap
@@ -60,7 +60,7 @@ exports[`renders correctly with defaults 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>
@@ -185,7 +185,7 @@ exports[`renders correctly with title 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>


### PR DESCRIPTION
This is a bug fix for issue #144. Basically whenever a header title was long it would overlap the other header buttons and basically trap the user on the page because the text would block the buttons.

I refactored the nav bar code to use relative positioning instead of absolute positioning and I noticed that all of the pages on the app had a `topPadding` set to the size of the header. So that is why I have touched so many files in this PR.
# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

