### PR TITLE
Fix image cropping

### DIFF
--- a/src/components/SwipeSubject.js
+++ b/src/components/SwipeSubject.js
@@ -3,12 +3,14 @@ import {
   Animated,
   Easing,
   Image,
+  ImageBackground,
   View
 } from 'react-native';
 import PropTypes from 'prop-types';
 import EStyleSheet from 'react-native-extended-stylesheet'
-import StyledText from './StyledText'
+import FontedText from '../components/common/FontedText'
 import { indexOf } from 'ramda'
+import theme from '../theme'
 
 class SwipeSubject extends Component {
   constructor(props) {
@@ -18,10 +20,26 @@ class SwipeSubject extends Component {
       enterAnim: new Animated.Value(enterVal),
       topAnim: new Animated.Value(0),
       fadeAnim: new Animated.Value(0),
+      overlayViewWidth: this.props.subjectSizes.resizedWidth,
+      overlayViewHeight: this.props.subjectSizes.resizedHeight,
+      isSwipingRight: true
     }
+
+    props.pan.x.addListener(({value}) => this.setState({ isSwipingRight: value > 0}));
   }
 
   imageLoadEnd() {
+    // We need to get the image size and figure out the aspect ratio in order
+    // to properly fit the overlay view over it
+    Image.getSize(this.props.subject.display.src, (width, height) => {
+      const {resizedWidth, resizedHeight} = this.props.subjectSizes
+      const aspectRatio = Math.min(resizedWidth / width, resizedHeight / height)
+      this.setState({
+        overlayViewHeight: height * aspectRatio,
+        overlayViewWidth: width * aspectRatio
+      });
+    });
+
     const enterVal = this.props.inFront ? 1 : 0.9
     Animated.spring(
       this.state.enterAnim,
@@ -59,12 +77,28 @@ class SwipeSubject extends Component {
   }
 
   render() {
+    const panX = this.props.pan.x
+    const overlayColor = panX.interpolate({inputRange: [-200, 200], outputRange: [theme.$swipeLeft, theme.$swipeRight]})
+    const overlayOpacity = panX.interpolate({inputRange: [-200, 0, 200], outputRange: [.8, 0, .8]})
+
+    const overlayStyle = {
+      backgroundColor: overlayColor,
+      opacity: overlayOpacity,
+    }
+    const imageDimensionStyle = {
+      width: this.state.overlayViewWidth,
+      height: this.state.overlayViewHeight
+    }
     const alreadySeenThisSession = indexOf(this.props.subject.id, this.props.seenThisSession) >= 0
     const alreadySeen = this.props.subject.already_seen || alreadySeenThisSession
 
     const alreadySeenBanner =
-      <View style={styles.alreadySeen}>
-        <StyledText additionalStyles={[styles.alreadySeenText]} text={ 'ALREADY SEEN!' } />
+      <View style={imageDimensionStyle}>
+        <View style={styles.alreadySeen}>
+          <FontedText style={styles.alreadySeenText} >
+            ALREADY SEEN!
+          </FontedText>
+        </View>
       </View>
 
     const imageSizeStyle = { width: this.props.subjectSizes.resizedWidth, height: this.props.subjectSizes.resizedHeight }
@@ -79,14 +113,25 @@ class SwipeSubject extends Component {
       <Animated.View
         key={this.props.subject.id}
         style={[styles.container, {top: this.state.topAnim, transform: tranformProperties, opacity: this.state.fadeAnim}]}>
-        <View style={[styles.imageShadow, imageSizeStyle, {elevation: elevation}]}>
-          <Image
+        <View style={[imageSizeStyle, {elevation}]}>
+          <ImageBackground
             onLoadEnd={ ()=>{ this.imageLoadEnd() } }
             source={{uri: this.props.subject.display.src}}
-            style={[styles.image]}
+            style={[styles.image, styles.imageShadow]}
             resizeMethod="resize" 
-          />
-        { alreadySeen ? alreadySeenBanner : null }
+            resizeMode="contain"
+          >
+            <View style={[styles.overlayContainer]}>
+              { alreadySeen ? alreadySeenBanner : null }
+            </View>
+            <View style={[styles.overlayContainer, styles.centeredElements]}>
+              <Animated.View style={[overlayStyle, imageDimensionStyle, styles.centeredElements]}>
+                <FontedText style={styles.overlayText}>
+                  {this.state.isSwipingRight ? this.props.rightAnswer : this.props.leftAnswer}
+                </FontedText>
+              </Animated.View>
+            </View>            
+          </ImageBackground>
         </View>
       </Animated.View>
     )
@@ -104,7 +149,7 @@ const styles = EStyleSheet.create({
     alignItems: 'center',
   },
   imageShadow: {
-    backgroundColor: 'white',
+    backgroundColor: 'transparent',
     shadowColor: 'rgba(0, 0, 0, 0.24)',
     shadowOpacity: 0.8,
     shadowRadius: 2,
@@ -132,6 +177,21 @@ const styles = EStyleSheet.create({
     fontSize: 12,
     fontWeight: 'bold'
   },
+  overlayContainer: {
+    position: 'absolute',
+    top:0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  centeredElements: {
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  overlayText: {
+    fontSize: 30,
+    color: 'white'
+  }
 })
 
 SwipeSubject.propTypes = {
@@ -148,7 +208,18 @@ SwipeSubject.propTypes = {
     resizedHeight: PropTypes.number,
   }),
   seenThisSession: PropTypes.array,
-  setNextSubject: PropTypes.func
+  setNextSubject: PropTypes.func,
+  pan: PropTypes.shape({
+    x: PropTypes.any
+  }),
+  leftAnswer: PropTypes.string,
+  rightAnswer: PropTypes.string
+}
+
+SwipeSubject.defaultProps = {
+  pan: {
+    x: new Animated.Value(0)
+  }
 }
 
 export default SwipeSubject

--- a/src/components/Swipeable.js
+++ b/src/components/Swipeable.js
@@ -7,7 +7,6 @@ import {
   View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
-import theme from '../theme'
 import { connect } from 'react-redux'
 import StyledText from './StyledText'
 import SwipeSubject from './SwipeSubject'
@@ -19,8 +18,6 @@ import PropTypes from 'prop-types';
 //everything above and prevents it from being touchable
 const toTop = (Platform.OS === 'ios') ? 65 : 55
 const SWIPE_THRESHOLD = 90
-const leftOverlayColor = theme.$swipeLeft
-const rightOverlayColor = theme.$swipeRight
 
 const mapStateToProps = (state, ownProps) => ({
   workflow: state.main.classifier.workflow[ownProps.workflowID] || {},
@@ -97,29 +94,21 @@ export class Swipeable extends Component {
   }
 
   render() {
-    const imageSizeStyle = { width: this.props.subjectSizes.resizedWidth, height: this.props.subjectSizes.resizedHeight }
     const swipeableSize = { width: this.props.subjectSizes.resizedWidth, height: this.props.subjectSizes.resizedHeight + 10 }
     let pan = this.state.pan
 
     let [translateX, translateY] = [pan.x, pan.y]
 
     let rotate = pan.x.interpolate({inputRange: [-200, 0, 200], outputRange: ['-30deg', '0deg', '30deg']})
-    let opacityRight = pan.x.interpolate({inputRange: [0, 100, 200], outputRange: [0, .6, .8]})
-    let opacityLeft = pan.x.interpolate({inputRange: [-200, -100, 0], outputRange: [.8, .6, 0]})
-    let opacityRightText = pan.x.interpolate({inputRange: [0, 30], outputRange: [0, 1]})
-    let opacityLeftText = pan.x.interpolate({inputRange: [-30, 0], outputRange: [1, 0]})
+    
 
     let animatedCardStyles = {transform: [{translateX}, {translateY}, {rotate}]}
-    let leftOverlayStyle = {backgroundColor: leftOverlayColor, opacity: opacityLeft}
-    let rightOverlayStyle = {backgroundColor: rightOverlayColor, opacity: opacityRight}
-    let leftOverlayTextStyle = {opacity: opacityLeftText}
-    let rightOverlayTextStyle = {opacity: opacityRightText}
 
     return (
       <View style={[styles.container, {top: toTop + this.props.questionContainerHeight, height: this.props.subjectSizes.resizedHeight + 40}]}>
         <View style={styles.subjectContainer}>
           <Animated.View
-            style={[styles.imageContainer, animatedCardStyles, swipeableSize]}
+            style={[animatedCardStyles, swipeableSize]}
             {...this._panResponder.panHandlers}>
 
             <TouchableOpacity
@@ -132,16 +121,10 @@ export class Swipeable extends Component {
                 subjectSizes={this.props.subjectSizes}
                 seenThisSession={this.props.seenThisSession}
                 setNextSubject={this.props.setNextSubject}
+                pan={pan}
+                leftAnswer={this.props.answers[0].label}
+                rightAnswer={this.props.answers[1].label}
               />
-              <Animated.View style={[styles.overlayContainer, leftOverlayStyle, imageSizeStyle]} />
-              <Animated.View style={[styles.overlayContainer, leftOverlayTextStyle, imageSizeStyle]}>
-                <StyledText additionalStyles={[styles.answerOverlayText]} text={ this.props.answers[0].label } />
-              </Animated.View>
-
-              <Animated.View style={[styles.overlayContainer, rightOverlayStyle, imageSizeStyle]} />
-              <Animated.View style={[styles.overlayContainer, rightOverlayTextStyle, imageSizeStyle]}>
-                <StyledText additionalStyles={[styles.answerOverlayText]} text={ this.props.answers[1].label } />
-              </Animated.View>
             </TouchableOpacity>
           </Animated.View>
         </View>
@@ -172,21 +155,6 @@ const styles = EStyleSheet.create({
     backgroundColor: 'transparent',
     alignItems: 'center',
     justifyContent: 'flex-start',
-  },
-  overlayContainer: {
-    borderRadius: 2,
-    backgroundColor: 'transparent',
-    position: 'absolute',
-    top: 20,
-    right: 0,
-    left: 0,
-    bottom: 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  answerOverlayText: {
-    fontSize: 30,
-    color: 'white'
   },
 })
 

--- a/src/components/ZoomableImage.js
+++ b/src/components/ZoomableImage.js
@@ -5,11 +5,6 @@ import {
 } from 'react-native'
 import ImageZoom from 'react-native-image-pan-zoom'
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux'
-
-const mapStateToProps = (state) => ({
-  subjectDisplayHeight: state.main.device.subjectDisplayHeight
-})
 
 export const ZoomableImage = (props) => {
   return (
@@ -17,15 +12,16 @@ export const ZoomableImage = (props) => {
       cropWidth={Dimensions.get('window').width}
       cropHeight={Dimensions.get('window').height}
       imageWidth={Dimensions.get('window').width}
-      imageHeight={props.subjectDisplayHeight}
+      imageHeight={Dimensions.get('window').height}
       panToMove={ props.allowPanAndZoom }
       pinchToZoom={ props.allowPanAndZoom }
       onLongPress={props.handlePress}
       longPressTime={ 300 }>
       <Image
         source={ props.source }
-        style={{width: Dimensions.get('window').width, height: props.subjectDisplayHeight}} 
+        style={{width: Dimensions.get('window').width, height: Dimensions.get('window').height}} 
         resizeMethod="resize"
+        resizeMode="contain"
       />
     </ImageZoom>
   )
@@ -37,10 +33,7 @@ ZoomableImage.propTypes = {
     uri: PropTypes.string,
   }),
   handlePress: PropTypes.func,
-  imageWidth: PropTypes.number,
-  imageHeight: PropTypes.number,
   allowPanAndZoom: PropTypes.bool,
-  subjectDisplayHeight: PropTypes.number
 }
 
-export default connect(mapStateToProps)(ZoomableImage);
+export default ZoomableImage

--- a/src/components/__tests__/__snapshots__/SwipeSubject-test.js.snap
+++ b/src/components/__tests__/__snapshots__/SwipeSubject-test.js.snap
@@ -21,7 +21,6 @@ exports[`renders already seen if already_seen is on subject 1`] = `
   <View
     style={
       Array [
-        undefined,
         Object {
           "height": 100,
           "width": 100,
@@ -32,38 +31,110 @@ exports[`renders already seen if already_seen is on subject 1`] = `
       ]
     }
   >
-    <Image
-      onLoadEnd={[Function]}
-      resizeMethod="resize"
-      source={
-        Object {
-          "uri": "blah.jpg",
-        }
-      }
+    <View
       style={
         Array [
           undefined,
+          undefined,
         ]
       }
-    />
-    <View
-      style={undefined}
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
+      <Image
+        onLoadEnd={[Function]}
+        resizeMethod="resize"
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "blah.jpg",
+          }
+        }
+        style={
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "height": undefined,
+              "width": undefined,
+            },
+            undefined,
+          ]
+        }
+      />
+      <View
         style={
           Array [
             undefined,
-            Array [
-              undefined,
-            ],
           ]
         }
       >
-        ALREADY SEEN!
-      </Text>
+        <View
+          style={
+            Object {
+              "height": 100,
+              "width": 100,
+            }
+          }
+        >
+          <View
+            style={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "Karla",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              ALREADY SEEN!
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "backgroundColor": "rgba(114, 120, 119, 1)",
+              "height": 100,
+              "opacity": 0,
+              "width": 100,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontFamily": "Karla",
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -90,7 +161,6 @@ exports[`renders already seen if it was seen this session 1`] = `
   <View
     style={
       Array [
-        undefined,
         Object {
           "height": 100,
           "width": 100,
@@ -101,38 +171,110 @@ exports[`renders already seen if it was seen this session 1`] = `
       ]
     }
   >
-    <Image
-      onLoadEnd={[Function]}
-      resizeMethod="resize"
-      source={
-        Object {
-          "uri": "blah.jpg",
-        }
-      }
+    <View
       style={
         Array [
           undefined,
+          undefined,
         ]
       }
-    />
-    <View
-      style={undefined}
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
+      <Image
+        onLoadEnd={[Function]}
+        resizeMethod="resize"
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "blah.jpg",
+          }
+        }
+        style={
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "height": undefined,
+              "width": undefined,
+            },
+            undefined,
+          ]
+        }
+      />
+      <View
         style={
           Array [
             undefined,
-            Array [
-              undefined,
-            ],
           ]
         }
       >
-        ALREADY SEEN!
-      </Text>
+        <View
+          style={
+            Object {
+              "height": 100,
+              "width": 100,
+            }
+          }
+        >
+          <View
+            style={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "Karla",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              ALREADY SEEN!
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "backgroundColor": "rgba(114, 120, 119, 1)",
+              "height": 100,
+              "opacity": 0,
+              "width": 100,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontFamily": "Karla",
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -159,7 +301,6 @@ exports[`renders back subject position correctly 1`] = `
   <View
     style={
       Array [
-        undefined,
         Object {
           "height": 100,
           "width": 100,
@@ -170,20 +311,82 @@ exports[`renders back subject position correctly 1`] = `
       ]
     }
   >
-    <Image
-      onLoadEnd={[Function]}
-      resizeMethod="resize"
-      source={
-        Object {
-          "uri": "blah.jpg",
-        }
-      }
+    <View
       style={
         Array [
           undefined,
+          undefined,
         ]
       }
-    />
+    >
+      <Image
+        onLoadEnd={[Function]}
+        resizeMethod="resize"
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "blah.jpg",
+          }
+        }
+        style={
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "height": undefined,
+              "width": undefined,
+            },
+            undefined,
+          ]
+        }
+      />
+      <View
+        style={
+          Array [
+            undefined,
+          ]
+        }
+      />
+      <View
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "backgroundColor": "rgba(114, 120, 119, 1)",
+              "height": 100,
+              "opacity": 0,
+              "width": 100,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontFamily": "Karla",
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;
@@ -206,7 +409,6 @@ exports[`renders front subject position correctly 1`] = `
   <View
     style={
       Array [
-        undefined,
         Object {
           "height": 100,
           "width": 100,
@@ -217,20 +419,82 @@ exports[`renders front subject position correctly 1`] = `
       ]
     }
   >
-    <Image
-      onLoadEnd={[Function]}
-      resizeMethod="resize"
-      source={
-        Object {
-          "uri": "blah.jpg",
-        }
-      }
+    <View
       style={
         Array [
           undefined,
+          undefined,
         ]
       }
-    />
+    >
+      <Image
+        onLoadEnd={[Function]}
+        resizeMethod="resize"
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "blah.jpg",
+          }
+        }
+        style={
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "height": undefined,
+              "width": undefined,
+            },
+            undefined,
+          ]
+        }
+      />
+      <View
+        style={
+          Array [
+            undefined,
+          ]
+        }
+      />
+      <View
+        style={
+          Array [
+            undefined,
+            undefined,
+          ]
+        }
+      >
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "backgroundColor": "rgba(114, 120, 119, 1)",
+              "height": 100,
+              "opacity": 0,
+              "width": 100,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontFamily": "Karla",
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;

--- a/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Swipeable-test.js.snap
@@ -76,6 +76,14 @@ exports[`renders correctly 1`] = `
       >
         <SwipeSubject
           inFront={true}
+          leftAnswer="No"
+          pan={
+            Object {
+              "x": 0,
+              "y": 0,
+            }
+          }
+          rightAnswer="Yes"
           seenThisSession={undefined}
           setNextSubject={undefined}
           subject={
@@ -90,80 +98,6 @@ exports[`renders correctly 1`] = `
             }
           }
         />
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "backgroundColor": "#E45950",
-              "height": 100,
-              "opacity": 0,
-              "width": 100,
-            }
-          }
-        />
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "height": 100,
-              "opacity": 0,
-              "width": 100,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Array [
-                undefined,
-                Array [
-                  undefined,
-                ],
-              ]
-            }
-          >
-            No
-          </Text>
-        </View>
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "backgroundColor": "#00979D",
-              "height": 100,
-              "opacity": 0,
-              "width": 100,
-            }
-          }
-        />
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "height": 100,
-              "opacity": 0,
-              "width": 100,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Array [
-                undefined,
-                Array [
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Yes
-          </Text>
-        </View>
       </View>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/ZoomableImage-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ZoomableImage-test.js.snap
@@ -4,7 +4,7 @@ exports[`renders correctly 1`] = `
 <ImageZoom
   cropHeight={1334}
   cropWidth={750}
-  imageHeight={undefined}
+  imageHeight={1334}
   imageWidth={750}
   longPressTime={300}
   onLongPress={[Function]}
@@ -13,6 +13,7 @@ exports[`renders correctly 1`] = `
 >
   <Image
     resizeMethod="resize"
+    resizeMode="contain"
     source={
       Object {
         "uri": "https://placekitten.com/200/300",
@@ -20,7 +21,7 @@ exports[`renders correctly 1`] = `
     }
     style={
       Object {
-        "height": undefined,
+        "height": 1334,
         "width": 750,
       }
     }


### PR DESCRIPTION
Fixing some issues caused by  #159.

Namely that I was not correctly implementing the automatic resizing provided in react. Before this code change, the images were being cropped to be a specific size, now they are actually scaled down.

Unfortunately, we still have to use `Image.getSize` to calculate the size of the overlay view. However, now if that function fails, we still see the image, the overlay view will just be a little to big.

We have to use this function because React Native doesn't provide any way to know the size of an automatically resized image.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

