### PR TITLE
Update Android Target Version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,13 +96,13 @@ def enableProguardInReleaseBuilds = false
 def pass = getPassword("android@zooniverse.org","android_keystore")
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.zooniversemobile"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 17
         versionName "2.1.0"
         multiDexEnabled true


### PR DESCRIPTION
Fixes #196

Google is forcing an Android SDK update.

WARNING: 

You will have to download the SDK 27. You can do this through the Android Studio SDK Manager. You will also have to download the SDK Android Build Tools version 27.0.3.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

