### PR TITLE
Update Android Manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,6 @@
         android:exported="true"
       >
         <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
             <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>


### PR DESCRIPTION
Fixes a bug where two icons show on Android.

Testing:
Installing the Android app on a simulator or device will only show one icon. 

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

