### PR TITLE
Fix Tutorial View

### DIFF
--- a/__mocks__/react-native-swiper.js
+++ b/__mocks__/react-native-swiper.js
@@ -1,0 +1,4 @@
+import { createMockComponent } from './mockUtils'
+
+const Swiper = createMockComponent('Swiper');
+export default Swiper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,11 +46,6 @@
         }
       }
     },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1506,6 +1501,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
     },
     "base64-js": {
       "version": "1.2.1",
@@ -4219,6 +4219,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4227,14 +4235,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8440,8 +8440,8 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
           "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
           "requires": {
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.3.1"
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1"
           }
         }
       }
@@ -8585,6 +8585,14 @@
         "color": "2.0.1",
         "lodash": "4.17.5",
         "pegjs": "0.10.0"
+      }
+    },
+    "react-native-swiper": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/react-native-swiper/-/react-native-swiper-1.5.13.tgz",
+      "integrity": "sha512-byBPx3qz3FvZhk4O8LR8am5SoO/pwm2Sj1OmFuXOOLYEj87+PzQaTr9u7+mgU76Ti2TP1OWnCPTXH6XUXYwxyw==",
+      "requires": {
+        "prop-types": "15.6.0"
       }
     },
     "react-native-tab-view": {
@@ -9611,6 +9619,11 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -9647,11 +9660,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-native-simple-store": "^1.1.0",
     "react-native-splash-screen": "^3.0.6",
     "react-native-svg": "^6.1.3",
+    "react-native-swiper": "^1.5.13",
     "react-native-vector-icons": "^5.0.0",
     "react-native-webview-bridge": "^0.33.0",
     "react-redux": "^4.4.5",

--- a/src/actions/images.js
+++ b/src/actions/images.js
@@ -1,13 +1,11 @@
+import RNFetchBlob from 'rn-fetch-blob'
 import * as ActionConstants from '../constants/actions'
 import { loadRemoteImageToCache } from '../utils/imageUtils'
 
 export const loadImageToCache = (remoteSource) => {
     return (dispatch, getState) => {
         return new Promise((resolve, reject) => {
-            const cachedImagePath = getState().images[remoteSource]
-            if (cachedImagePath) {
-                resolve(cachedImagePath)
-            } else {
+            const loadImage = () => {
                 loadRemoteImageToCache(remoteSource).then((localSource) => {
                     dispatch(saveImageLocation(remoteSource, localSource))
                     resolve(localSource)
@@ -15,6 +13,20 @@ export const loadImageToCache = (remoteSource) => {
                 .catch((error) => {
                     reject(error)
                 })
+            }
+
+            const cachedImagePath = getState().images[remoteSource]
+            if (cachedImagePath) {
+                RNFetchBlob.fs.exists(cachedImagePath)
+                .then((fileExists) => {
+                    if (fileExists) {
+                        resolve(cachedImagePath)
+                    } else {
+                        loadImage()
+                    }
+                })                
+            } else {
+                loadImage()
             }
         })
     }

--- a/src/components/classifier/ClassificationPanel.js
+++ b/src/components/classifier/ClassificationPanel.js
@@ -29,7 +29,7 @@ class ClassificationPanel extends Component {
 
     return (
       <View style={styles.container}>
-        <View style={[styles.panelContainer, this.props.isQuestionVisible ? styles.questionMargin : styles.tutorialMargin]}>
+        <View style={styles.panelContainer}>
           { this.props.hasTutorial ? tabs : null }
           { this.props.children }
         </View>
@@ -50,12 +50,7 @@ const styles = EStyleSheet.create({
     backgroundColor: 'white',
     marginTop: 15,
     marginBottom: 0,
-  },
-  questionMargin: {
     marginHorizontal: 25
-  },
-  tutorialMargin: {
-    marginHorizontal: 0
   },
   tabContainer: {
     flexDirection: 'row',

--- a/src/components/classifier/ClassificationPanel.js
+++ b/src/components/classifier/ClassificationPanel.js
@@ -29,7 +29,7 @@ class ClassificationPanel extends Component {
 
     return (
       <View style={styles.container}>
-        <View style={styles.panelContainer}>
+        <View style={[styles.panelContainer, this.props.isQuestionVisible ? styles.questionMargin : styles.tutorialMargin]}>
           { this.props.hasTutorial ? tabs : null }
           { this.props.children }
         </View>
@@ -49,8 +49,13 @@ const styles = EStyleSheet.create({
     flex: 1,
     backgroundColor: 'white',
     marginTop: 15,
-    marginHorizontal: '$panelHorizontalMargin',
     marginBottom: 0,
+  },
+  questionMargin: {
+    marginHorizontal: 25
+  },
+  tutorialMargin: {
+    marginHorizontal: 0
   },
   tabContainer: {
     flexDirection: 'row',

--- a/src/components/classifier/SwipeClassifier.js
+++ b/src/components/classifier/SwipeClassifier.js
@@ -268,7 +268,8 @@ export class SwipeClassifier extends React.Component {
 
 const styles = EStyleSheet.create({
   container: {
-    flex: 1
+    flex: 1,
+    marginBottom: 15
   },
   classificationPanel: { 
     flex: 1,

--- a/src/components/classifier/SwipeTabs.js
+++ b/src/components/classifier/SwipeTabs.js
@@ -59,7 +59,7 @@ export class SwipeTabs extends Component {
 const styles = EStyleSheet.create({
   container: {
     marginHorizontal: 25,
-    marginVertical: 15,
+    marginTop: 15,
     backgroundColor: 'transparent',
     flexDirection: 'row',
     justifyContent: 'space-around'

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -33,7 +33,7 @@ export class Tutorial extends Component {
     const tutorialSteps = steps.map((step, index) => {
       return (
         <TutorialStep
-          key={`${index}`}
+          key={`TUTORIAL_STEP_${index}`}
           markdownContent={step.content}
           mediaUri={this.props.tutorial.mediaResources && this.props.tutorial.mediaResources[step.media] ? this.props.tutorial.mediaResources[step.media].src : null}
         />
@@ -69,7 +69,7 @@ export class Tutorial extends Component {
     const renderCircle = (currentStep, index) => {
       return (
         <TouchableOpacity
-          key={ index }
+          key={ `PAGINATION_DOT_${index}` }
           onPress={() => this.swiper.scrollBy(index - this.state.step, false)}>
           <Icon
             name={ currentStep === index ? 'circle' : 'circle-thin'}

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -30,7 +30,7 @@ export class Tutorial extends Component {
     const steps = this.props.tutorial.steps
     const totalSteps = length(steps)
     
-    const tutorialStep = steps.map((step, index) => {
+    const tutorialSteps = steps.map((step, index) => {
       return (
         <TutorialStep
           key={`${index}`}
@@ -117,7 +117,7 @@ export class Tutorial extends Component {
             loop={false}
             onIndexChanged={(index) => this.setState({step: index})}
           >
-            {tutorialStep}
+            {tutorialSteps}
           </Swiper>
         </View>
         <View style={styles.footer}>

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import {
-  Dimensions,
   Platform,
   ScrollView,
   StyleSheet,
@@ -8,13 +7,14 @@ import {
   View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
-import PropTypes from 'prop-types';
-import StyledMarkdown from '../StyledMarkdown'
-import StyledText from '../StyledText'
-import SizedImage from '../SizedImage'
-import Button from '../Button'
+import Markdown from 'react-native-simple-markdown'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import { addIndex, length, map } from 'ramda'
+import PropTypes from 'prop-types';
+
+import StyledText from '../StyledText'
+import Button from '../Button'
+import FittedImage from '../common/FittedImage'
 
 const topPadding = (Platform.OS === 'ios') ? 10 : 0
 
@@ -26,6 +26,16 @@ export class Tutorial extends Component {
       sizedHeight: 0,
       sizedWidth: 0,
     }
+
+    this.onScrollViewLayout = this.onScrollViewLayout.bind(this)
+  }
+
+  onScrollViewLayout({ nativeEvent }) {
+    const { width } = nativeEvent.layout
+    this.setState({
+      sizedHeight: width,
+      sizedWidth: width
+    })
   }
 
   render() {
@@ -34,7 +44,7 @@ export class Tutorial extends Component {
     const totalSteps = length(steps)
 
     const mediaResource = (step.media ? this.props.tutorial.mediaResources[step.media] : null )
-    const mediaImage = (mediaResource !== null ? <SizedImage source={{ uri: mediaResource.src }} /> : null)
+    const mediaImage = (mediaResource !== null ? <FittedImage maxWidth={this.state.sizedWidth} maxHeight={this.state.sizedHeight} source={{ uri: mediaResource.src }} /> : null)
 
     const hasPreviousStep = this.state.step > 0
     const previousStep =
@@ -107,11 +117,14 @@ export class Tutorial extends Component {
       <View style={styles.container}>
         { this.props.isInitialTutorial ? tutorialHeader : null}
         <ScrollView style={styles.content} contentContainerStyle={styles.scrollViewContainerStyle}>
-          { mediaImage }
-          <StyledMarkdown
-            width={ Dimensions.get('window').width - 80 }
-            markdown={steps[this.state.step].content}
-          />
+          <View style={styles.container} onLayout={this.onScrollViewLayout}>
+            { mediaImage }
+            <View style={styles.markdown} >
+              <Markdown >
+                { steps[this.state.step].content }
+              </Markdown>
+            </View>
+          </View>
         </ScrollView>
         <View style={styles.footer}>
           <View style={styles.line} />
@@ -192,6 +205,10 @@ const styles = EStyleSheet.create({
     marginBottom: 0,
     paddingTop: topPadding,
     paddingBottom: 0,
+  },
+  markdown: {
+    flex: 1,
+    marginTop: 15
   }
 })
 

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -35,7 +35,7 @@ export class Tutorial extends Component {
         <TutorialStep
           key={`${index}`}
           markdownContent={step.content}
-          mediaUri={this.props.tutorial.mediaResources[step.media] ? this.props.tutorial.mediaResources[step.media].src : null}
+          mediaUri={this.props.tutorial.mediaResources && this.props.tutorial.mediaResources[step.media] ? this.props.tutorial.mediaResources[step.media].src : null}
         />
       )
     })

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react'
+import {
+    Dimensions,
+    ScrollView,
+    View
+} from 'react-native'
+import PropTypes from 'prop-types'
+import Markdown from 'react-native-simple-markdown'
+
+import FittedImage from '../common/FittedImage' 
+
+const ImageWidth = Dimensions.get('window').width - 100
+class TutorialStep extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            width: 1,
+            displayStep: this.props.mediaUri === null
+        }
+
+        this.onLayout = this.onLayout.bind(this)
+    }
+
+    onLayout({nativeEvent}) {
+        this.setState({
+            width: nativeEvent.layout.width
+        })
+    }
+
+    render() {
+        return (
+            <ScrollView style={styles.container}>
+                <View style={styles.container}>
+                    <View style={styles.contentContainer} onLayout={this.onLayout}>
+                        {
+                            this.props.mediaUri ?
+                                <FittedImage 
+                                    maxWidth={ImageWidth}
+                                    maxHeight={ImageWidth}
+                                    source={{ uri: this.props.mediaUri }}
+                                    onLoad={() => this.setState({displayStep: true})}
+                                />
+                            : null
+                        }
+
+                        <View style={styles.markdown} >
+                            <Markdown >
+                                { this.props.markdownContent }
+                            </Markdown>
+                        </View>
+                    </View>
+                </View>
+            </ScrollView>
+        )
+    }
+}
+
+const styles = {
+    markdown: {
+        flex: 1,
+        marginTop: 15
+      },
+      container: {
+          flex: 1
+      },
+      contentContainer: {
+          flex: 1,
+          margin: 25
+      }
+}
+
+TutorialStep.propTypes = {
+    markdownContent: PropTypes.string,
+    mediaUri: PropTypes.string,
+    width: PropTypes.number
+}
+
+export default TutorialStep        

--- a/src/components/classifier/__tests__/__snapshots__/Tutorial-test.js.snap
+++ b/src/components/classifier/__tests__/__snapshots__/Tutorial-test.js.snap
@@ -4,122 +4,229 @@ exports[`renders correctly 1`] = `
 <View
   style={undefined}
 >
-  <RCTScrollView
-    contentContainerStyle={undefined}
+  <View
     style={undefined}
   >
-    <View>
-      <SizedImage
-        source={
-          Object {
-            "uri": "http://notvalid",
-          }
-        }
-      />
-      <WebView
-        automaticallyAdjustContentInsets={true}
-        domStorageEnabled={true}
-        javaScriptEnabled={true}
-        onNavigationStateChange={[Function]}
-        onShouldStartLoadWithRequest={[Function]}
-        scalesPageToFit={true}
-        source={
-          Object {
-            "baseUrl": "about:blank",
-            "html": "<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset=\\"utf-8\\">
-        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-        <meta name=\\"viewport\\" content=\\"initial-scale=1, maximum-scale=1\\">
-        <meta name=\\"format-detection\\" content=\\"telephone=no\\">
-        <meta name=\\"format-detection\\" content=\\"date=no\\">
-        <meta name=\\"format-detection\\" content=\\"address=no\\">
-        <meta name=\\"format-detection\\" content=\\"email=no\\">
-
-        <title></title>
-
-
-        <style type=\\"text/css\\">
-            body, html, #height-wrapper {
-                margin: 0;
-                padding: 0;
-            }
-            #height-wrapper {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-            }
-            body {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-            }
-            b, strong {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: bold;
-            }
-            h1, h2, h3, h4, h5, h6 {
-                margin-top: 10px;
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: 500;
-            }
-            img {
-              height: auto;
-              width: auto;
-              max-width: 300px;
-              max-height: 300px;
-            }
-            p {
-              margin: 0;
-            }
-            
-        </style>
-    </head>
-    <body>
-        <h3>Welcome to Planet Four: Ridges</h3>
-<hr>
-<p>This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past.</p>
-
-
-    <script>
-
-    ;(function() {
-    var wrapper = document.createElement(\\"div\\");
-    wrapper.id = \\"height-wrapper\\";
-    while (document.body.firstChild) {
-        wrapper.appendChild(document.body.firstChild);
-    }
-    document.body.appendChild(wrapper);
-    var i = 0;
-    function updateHeight() {
-        document.title = wrapper.clientHeight;
-        window.location.hash = ++i;
-    }
-    updateHeight();
-    window.addEventListener(\\"load\\", function() {
-        updateHeight();
-        setTimeout(updateHeight, 1000);
-    });
-    window.addEventListener(\\"resize\\", updateHeight);
-    }());
-
-    </script>
-    </body>
-</html>",
-          }
-        }
+    <Swiper
+      loop={false}
+      onIndexChanged={[Function]}
+      showsPagination={false}
+    >
+      <RCTScrollView
         style={
-          Array [
-            undefined,
-            Object {
-              "height": 0,
-              "width": 670,
-            },
-          ]
+          Object {
+            "flex": 1,
+          }
         }
-      />
-    </View>
-  </RCTScrollView>
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  ### Welcome to Planet Four: Ridges
+----------
+This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
+
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
+
+
+###### Image(c) : NASA/JPL/University of Arizona
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+    </Swiper>
+  </View>
   <View
     style={undefined}
   >
@@ -408,122 +515,229 @@ exports[`renders header if initial tutorial 1`] = `
   >
     Awesome project - Tutorial
   </Text>
-  <RCTScrollView
-    contentContainerStyle={undefined}
+  <View
     style={undefined}
   >
-    <View>
-      <SizedImage
-        source={
-          Object {
-            "uri": "http://notvalid",
-          }
-        }
-      />
-      <WebView
-        automaticallyAdjustContentInsets={true}
-        domStorageEnabled={true}
-        javaScriptEnabled={true}
-        onNavigationStateChange={[Function]}
-        onShouldStartLoadWithRequest={[Function]}
-        scalesPageToFit={true}
-        source={
-          Object {
-            "baseUrl": "about:blank",
-            "html": "<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset=\\"utf-8\\">
-        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-        <meta name=\\"viewport\\" content=\\"initial-scale=1, maximum-scale=1\\">
-        <meta name=\\"format-detection\\" content=\\"telephone=no\\">
-        <meta name=\\"format-detection\\" content=\\"date=no\\">
-        <meta name=\\"format-detection\\" content=\\"address=no\\">
-        <meta name=\\"format-detection\\" content=\\"email=no\\">
-
-        <title></title>
-
-
-        <style type=\\"text/css\\">
-            body, html, #height-wrapper {
-                margin: 0;
-                padding: 0;
-            }
-            #height-wrapper {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-            }
-            body {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-            }
-            b, strong {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: bold;
-            }
-            h1, h2, h3, h4, h5, h6 {
-                margin-top: 10px;
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: 500;
-            }
-            img {
-              height: auto;
-              width: auto;
-              max-width: 300px;
-              max-height: 300px;
-            }
-            p {
-              margin: 0;
-            }
-            
-        </style>
-    </head>
-    <body>
-        <h3>Welcome to Planet Four: Ridges</h3>
-<hr>
-<p>This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past.</p>
-
-
-    <script>
-
-    ;(function() {
-    var wrapper = document.createElement(\\"div\\");
-    wrapper.id = \\"height-wrapper\\";
-    while (document.body.firstChild) {
-        wrapper.appendChild(document.body.firstChild);
-    }
-    document.body.appendChild(wrapper);
-    var i = 0;
-    function updateHeight() {
-        document.title = wrapper.clientHeight;
-        window.location.hash = ++i;
-    }
-    updateHeight();
-    window.addEventListener(\\"load\\", function() {
-        updateHeight();
-        setTimeout(updateHeight, 1000);
-    });
-    window.addEventListener(\\"resize\\", updateHeight);
-    }());
-
-    </script>
-    </body>
-</html>",
-          }
-        }
+    <Swiper
+      loop={false}
+      onIndexChanged={[Function]}
+      showsPagination={false}
+    >
+      <RCTScrollView
         style={
-          Array [
-            undefined,
-            Object {
-              "height": 0,
-              "width": 670,
-            },
-          ]
+          Object {
+            "flex": 1,
+          }
         }
-      />
-    </View>
-  </RCTScrollView>
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  ### Welcome to Planet Four: Ridges
+----------
+This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
+
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
+
+
+###### Image(c) : NASA/JPL/University of Arizona
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 650,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Image
+                  resizeMode="contain"
+                  source={
+                    Object {
+                      "uri": "http://notvalid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 650,
+                      "width": 650,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+    </Swiper>
+  </View>
   <View
     style={undefined}
   >
@@ -797,115 +1011,142 @@ exports[`renders with no media 1`] = `
 <View
   style={undefined}
 >
-  <RCTScrollView
-    contentContainerStyle={undefined}
+  <View
     style={undefined}
   >
-    <View>
-      <WebView
-        automaticallyAdjustContentInsets={true}
-        domStorageEnabled={true}
-        javaScriptEnabled={true}
-        onNavigationStateChange={[Function]}
-        onShouldStartLoadWithRequest={[Function]}
-        scalesPageToFit={true}
-        source={
+    <Swiper
+      loop={false}
+      onIndexChanged={[Function]}
+      showsPagination={false}
+    >
+      <RCTScrollView
+        style={
           Object {
-            "baseUrl": "about:blank",
-            "html": "<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset=\\"utf-8\\">
-        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-        <meta name=\\"viewport\\" content=\\"initial-scale=1, maximum-scale=1\\">
-        <meta name=\\"format-detection\\" content=\\"telephone=no\\">
-        <meta name=\\"format-detection\\" content=\\"date=no\\">
-        <meta name=\\"format-detection\\" content=\\"address=no\\">
-        <meta name=\\"format-detection\\" content=\\"email=no\\">
-
-        <title></title>
-
-
-        <style type=\\"text/css\\">
-            body, html, #height-wrapper {
-                margin: 0;
-                padding: 0;
-            }
-            #height-wrapper {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-            }
-            body {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-            }
-            b, strong {
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: bold;
-            }
-            h1, h2, h3, h4, h5, h6 {
-                margin-top: 10px;
-                font-family: \\"Open Sans\\", \\"Gill Sans\\", Arial, sans-serif;
-                font-weight: 500;
-            }
-            img {
-              height: auto;
-              width: auto;
-              max-width: 300px;
-              max-height: 300px;
-            }
-            p {
-              margin: 0;
-            }
-            
-        </style>
-    </head>
-    <body>
-        <h3>Welcome to Planet Four: Ridges</h3>
-<hr>
-<p>This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past.</p>
-
-
-    <script>
-
-    ;(function() {
-    var wrapper = document.createElement(\\"div\\");
-    wrapper.id = \\"height-wrapper\\";
-    while (document.body.firstChild) {
-        wrapper.appendChild(document.body.firstChild);
-    }
-    document.body.appendChild(wrapper);
-    var i = 0;
-    function updateHeight() {
-        document.title = wrapper.clientHeight;
-        window.location.hash = ++i;
-    }
-    updateHeight();
-    window.addEventListener(\\"load\\", function() {
-        updateHeight();
-        setTimeout(updateHeight, 1000);
-    });
-    window.addEventListener(\\"resize\\", updateHeight);
-    }());
-
-    </script>
-    </body>
-</html>",
+            "flex": 1,
           }
         }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  ### Welcome to Planet Four: Ridges
+----------
+This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
+
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
         style={
-          Array [
-            undefined,
-            Object {
-              "height": 0,
-              "width": 670,
-            },
-          ]
+          Object {
+            "flex": 1,
+          }
         }
-      />
-    </View>
-  </RCTScrollView>
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
+
+
+###### Image(c) : NASA/JPL/University of Arizona
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+      <RCTScrollView
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+              style={
+                Object {
+                  "flex": 1,
+                  "margin": 25,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                <Markdown>
+                  Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
+                </Markdown>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+    </Swiper>
+  </View>
   <View
     style={undefined}
   >

--- a/src/components/common/FittedImage.js
+++ b/src/components/common/FittedImage.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react'
+import {
+    Image,
+    View
+} from 'react-native'
+import PropTypes from 'prop-types'
+
+class FittedImage extends Component {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            imageLayoutWidth: 1,
+            imageLayoutHeight: 1,
+            imageWidth: props.maxWidth,
+            imageHeight: props.maxHeight,
+        }
+    }
+
+    componentDidMount() {
+        Image.getSize(this.props.source.uri, (width, height) => {
+            this.setState({
+                imageWidth: width,
+                imageHeight: height,
+            })
+        })
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        const propsDimensionsChanged = prevProps.maxWidth !== this.props.maxWidth || prevProps.maxHeight !== this.props.maxHeight
+        const imageDimensionsCalculated = this.state.imageWidth !== prevState.imageWidth || this.state.imageHeight !== prevState.imageHeight
+        if (propsDimensionsChanged || imageDimensionsCalculated) {
+            const aspectRatio = Math.min(this.props.maxWidth / this.state.imageWidth, this.props.maxHeight / this.state.imageHeight)
+            const resizedHeight = this.state.imageHeight * aspectRatio
+            const resizedWidth = this.state.imageWidth * aspectRatio
+            this.setState({
+                imageWidth: resizedWidth,
+                imageHeight: resizedHeight
+            }, this.props.onLoad)
+        }
+    }
+
+    render() {
+        const imageStyle = {
+            width: this.state.imageWidth,
+            height: this.state.imageHeight,
+        }
+        const containerHeight = { height: this.state.imageHeight }
+
+        return (
+            <View style={ [containerHeight, styles.imageContainer] }>
+                <Image
+                    resizeMode="contain"
+                    source={this.props.source}
+                    style={imageStyle}
+                />
+            </View>
+        )
+    }
+}
+
+const styles = {
+    imageContainer: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center'
+    }
+}
+
+FittedImage.propTypes = {
+    source: PropTypes.object,
+    maxWidth: PropTypes.number,
+    maxHeight: PropTypes.number,
+    onLoad: PropTypes.func
+}
+
+export default FittedImage


### PR DESCRIPTION
Fixes #217 

# Changes
Refactored how the tutorial is displayed. It is now displayed as a paginating scroll view. Appearance-wise it looks identical, but it fixes a visual issue where the image load lags behind the markdown load.

Using a paginating scrollview, all of the content loads at once. This means the transition is smooth between pages.

Also, fix a bug that caused a crash with image caching.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

