### PR TITLE
Add tablet specific code/Assorted refactors

### DIFF
--- a/__mocks__/react-native-device-info.js
+++ b/__mocks__/react-native-device-info.js
@@ -1,0 +1,5 @@
+import { createMockComponent } from './mockUtils'
+
+const DeviceInfo = createMockComponent('DeviceInfo');
+DeviceInfo.isTablet = () => false
+export default DeviceInfo;

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -166,6 +166,7 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+" // From node_modules
+    compile project(':react-native-device-info')
 
     compile 'com.google.firebase:firebase-messaging:10.0.1'
     compile 'com.google.firebase:firebase-core:10.0.1'

--- a/android/app/src/main/java/com/zooniversemobile/MainApplication.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplication.java
@@ -15,6 +15,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.idehub.GoogleAnalyticsBridge.GoogleAnalyticsBridgePackage;
 import com.facebook.soloader.SoLoader;
+import com.learnium.RNDeviceInfo.RNDeviceInfo
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,10 +36,11 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
             new BlurViewPackage(),
             new RNFetchBlobPackage(),
             new SplashScreenReactPackage(),
-          new MainApplicationPackage(),
-          new GoogleAnalyticsBridgePackage(),
-          new SvgPackage(),
-          new FIRMessagingPackage()
+            new MainApplicationPackage(),
+            new GoogleAnalyticsBridgePackage(),
+            new SvgPackage(),
+            new FIRMessagingPackage(),
+            new RNDeviceInfo(),
       );
     }
 

--- a/android/app/src/main/java/com/zooniversemobile/MainApplication.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplication.java
@@ -40,7 +40,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
             new GoogleAnalyticsBridgePackage(),
             new SvgPackage(),
             new FIRMessagingPackage(),
-            new RNDeviceInfo(),
+            new RNDeviceInfo()
       );
     }
 

--- a/android/app/src/main/java/com/zooniversemobile/MainApplication.java
+++ b/android/app/src/main/java/com/zooniversemobile/MainApplication.java
@@ -15,7 +15,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.idehub.GoogleAnalyticsBridge.GoogleAnalyticsBridgePackage;
 import com.facebook.soloader.SoLoader;
-import com.learnium.RNDeviceInfo.RNDeviceInfo
+import com.learnium.RNDeviceInfo.RNDeviceInfo;
 
 import java.util.Arrays;
 import java.util.List;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,10 +16,11 @@ def getPassword(String currentUser, String keyChain) {
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -35,5 +36,6 @@ allprojects {
             url "$rootDir/../node_modules/react-native/android"
         }
         maven { url 'http://clojars.org/repo' }
+        google()
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 14 13:01:29 CDT 2018
+#Tue Nov 13 10:20:28 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,6 +9,8 @@ include ':rn-fetch-blob'
 project(':rn-fetch-blob').projectDir = new File(rootProject.projectDir, '../node_modules/rn-fetch-blob/android')
 include ':react-native-splash-screen'
 project(':react-native-splash-screen').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-splash-screen/android')
+include ':react-native-device-info'
+project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 
 include ':react-native-google-analytics-bridge', ':react-native-fcm', ':react-native-svg', ':app'
 project(':react-native-google-analytics-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-analytics-bridge/android')

--- a/ios/ZooniverseMobile.xcodeproj/project.pbxproj
+++ b/ios/ZooniverseMobile.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		01090E4220A9ED3800DBDD85 /* GoogleService-Info-prod.plist in Resources */ = {isa = PBXBuildFile; fileRef = 01090E1920A9ED3800DBDD85 /* GoogleService-Info-prod.plist */; };
 		01090E4520A9EEE800DBDD85 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01090E4420A9EEE800DBDD85 /* FirebaseManager.swift */; };
 		01090E4A20AB38A300DBDD85 /* NotificationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 01090E4920AB38A300DBDD85 /* NotificationSettings.m */; };
-		0115251D2099027600C6C093 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0115251C2099005600C6C093 /* SimpleLineIcons.ttf */; };
 		0125C11920FE7CE2009DCD28 /* libRNFetchBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0125C11820FE7CAA009DCD28 /* libRNFetchBlob.a */; };
 		01471F5420C09330007A22F4 /* ImageSizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 01471F5320C09330007A22F4 /* ImageSizer.m */; };
 		014AB847202374F80014915B /* libRCTGoogleAnalyticsBridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99E051C91D7F618700052983 /* libRCTGoogleAnalyticsBridge.a */; };
@@ -28,6 +27,7 @@
 		01DE937A205192F500E81CA7 /* Karla-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 01DE9376205192F500E81CA7 /* Karla-Regular.ttf */; };
 		01E9AF1B216D3F430089CAF1 /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E9AF1A216D3F3D0089CAF1 /* libRNVectorIcons.a */; };
 		01E9AF80216E9F7D0089CAF1 /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E9AF7C216E9F6E0089CAF1 /* libRNSVG.a */; };
+		01F6958E2187977E00DFB289 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01F695872187976D00DFB289 /* libRNDeviceInfo.a */; };
 		03D7FD9E241A406B8C2BD7F7 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 880A346EBC57404CBBBAEE9C /* Ionicons.ttf */; };
 		133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
 		139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
@@ -270,6 +270,20 @@
 			remoteGlobalIDString = 94DDAC5C1F3D024300EED511;
 			remoteInfo = "RNSVG-tvOS";
 		};
+		01F695862187976D00DFB289 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 01F695592187976D00DFB289 /* RNDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DA5891D81BA9A9FC002B4DB2;
+			remoteInfo = RNDeviceInfo;
+		};
+		01F695882187976D00DFB289 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 01F695592187976D00DFB289 /* RNDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E72EC1401F7ABB5A0001BC90;
+			remoteInfo = "RNDeviceInfo-tvOS";
+		};
 		139105C01AF99BAD00B5F7CC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
@@ -417,6 +431,7 @@
 		01DE9376205192F500E81CA7 /* Karla-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Karla-Regular.ttf"; path = "../assets/fonts/Karla-Regular.ttf"; sourceTree = "<group>"; };
 		01E9AEEA216D3F3D0089CAF1 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
 		01E9AF4D216E9F6E0089CAF1 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
+		01F695592187976D00DFB289 /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNDeviceInfo.xcodeproj; path = "../node_modules/react-native-device-info/ios/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; };
 		051453304969ED18A9A5693A /* libPods-ZooniverseMobile.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ZooniverseMobile.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
@@ -482,6 +497,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01F6958E2187977E00DFB289 /* libRNDeviceInfo.a in Frameworks */,
 				01E9AF80216E9F7D0089CAF1 /* libRNSVG.a in Frameworks */,
 				01E9AF1B216D3F430089CAF1 /* libRNVectorIcons.a in Frameworks */,
 				015B202F215EBDDB00CC2A37 /* libRNBlur.a in Frameworks */,
@@ -625,6 +641,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		01F6955A2187976D00DFB289 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				01F695872187976D00DFB289 /* libRNDeviceInfo.a */,
+				01F695892187976D00DFB289 /* libRNDeviceInfo-tvOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		139105B71AF99BAD00B5F7CC /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -700,6 +725,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				01F695592187976D00DFB289 /* RNDeviceInfo.xcodeproj */,
 				01E9AF4D216E9F6E0089CAF1 /* RNSVG.xcodeproj */,
 				01E9AEEA216D3F3D0089CAF1 /* RNVectorIcons.xcodeproj */,
 				015B1FFD215EBDC200CC2A37 /* RNBlur.xcodeproj */,
@@ -977,6 +1003,10 @@
 					ProjectRef = 015B1FFD215EBDC200CC2A37 /* RNBlur.xcodeproj */;
 				},
 				{
+					ProductGroup = 01F6955A2187976D00DFB289 /* Products */;
+					ProjectRef = 01F695592187976D00DFB289 /* RNDeviceInfo.xcodeproj */;
+				},
+				{
 					ProductGroup = 0125C11420FE7CAA009DCD28 /* Products */;
 					ProjectRef = 0125C11320FE7CAA009DCD28 /* RNFetchBlob.xcodeproj */;
 				},
@@ -1187,6 +1217,20 @@
 			remoteRef = 01E9AF7D216E9F6E0089CAF1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		01F695872187976D00DFB289 /* libRNDeviceInfo.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNDeviceInfo.a;
+			remoteRef = 01F695862187976D00DFB289 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		01F695892187976D00DFB289 /* libRNDeviceInfo-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNDeviceInfo-tvOS.a";
+			remoteRef = 01F695882187976D00DFB289 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		139105C11AF99BAD00B5F7CC /* libRCTSettings.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1332,7 +1376,6 @@
 				999F9C871DB7B4FA002B6AF0 /* OpenSans-Italic.ttf in Resources */,
 				999F9C861DB7B4FA002B6AF0 /* OpenSans-ExtraBoldItalic.ttf in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
-				0115251D2099027600C6C093 /* SimpleLineIcons.ttf in Resources */,
 				0154415820A4C33800C8BA5A /* GoogleService-Info-dev.plist in Resources */,
 				999F9C891DB7B4FA002B6AF0 /* OpenSans-LightItalic.ttf in Resources */,
 				999F9C8D1DB7B4FA002B6AF0 /* zoo-font.ttf in Resources */,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8446,6 +8446,11 @@
         }
       }
     },
+    "react-native-device-info": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-0.24.3.tgz",
+      "integrity": "sha512-usW00Wk6DoXH1eRSMt07j0uYvuka3SIEnJ9girlddAacyqwfa1QMVTN4eYmtaBzuMd/avhis8iHZQ3cLaR9CMA=="
+    },
     "react-native-dismiss-keyboard": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-native-browser-builtins": "^2.0.3",
     "react-native-checkbox-field": "^2.0.2",
     "react-native-deck-swiper": "github:zooniverse/react-native-deck-swiper",
+    "react-native-device-info": "^0.24.3",
     "react-native-drawer": "^2.3.0",
     "react-native-extended-stylesheet": "^0.8.1",
     "react-native-fcm": "11.3.1",

--- a/src/actions/classifier.js
+++ b/src/actions/classifier.js
@@ -105,14 +105,14 @@ export function saveClassification(workflow, subject) {
   }
 }
 
-export function submitDrawingClassification(workflow, subject, {clientHeight, clientWidth}) {
+export function submitDrawingClassification(shapes, workflow, subject, {clientHeight, clientWidth}) {
   return (dispatch, getState) => {
-    const { classifier, drawing } = getState()
+    const { classifier } = getState()
     const subjectStartTime = classifier.subjectStartTime[workflow.id]
     const subjectCompletionTime = (new Date).toISOString()
     const firstTask = workflow.first_task
     const tools = workflow.tasks[firstTask].tools
-    const annotations = constructDrawingAnnotations(drawing.shapes, tools, firstTask)
+    const annotations = constructDrawingAnnotations(shapes, tools, firstTask)
     apiClient.type('classifications').create({
       completed: true,
       annotations,

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -220,7 +220,7 @@ class DrawingClassifier extends Component {
                     {isQuestionVisible ? classification : tutorial}
                 </ClassificationPanel>
                 {isQuestionVisible && !R.isEmpty(this.props.help) && <NeedHelpButton onPress={() => this.classificationContainer.displayHelpModal()} /> }
-                {isQuestionVisible && this.props.guide && fieldGuideButton}
+                {isQuestionVisible && !R.empty(this.props.guide) && fieldGuideButton}
                 { isQuestionVisible && submitButton }
             </View>
 

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -147,7 +147,7 @@ class DrawingClassifier extends Component {
 
         // We validate that tools has at least one element earlier
         const tool = this.props.tools[0]
-        const warnForRequirements = this.state.modalHasBeenClosedOnce && R.keys(this.props.shapes).length < this.props.tools[0].min
+        const warnForRequirements = this.state.modalHasBeenClosedOnce && R.keys(this.props.shapes).length < tool.min
 
         const tutorial =
             <Tutorial
@@ -165,7 +165,7 @@ class DrawingClassifier extends Component {
                     taskHelp={this.props.help}
                 />
                 <ShapeInstructionsView
-                    { ...this.props.tools[0] }
+                    { ...tool }
                     numberDrawn={this.props.numberOfShapesDrawn}
                     warnForRequirements={warnForRequirements}
                 />
@@ -200,7 +200,7 @@ class DrawingClassifier extends Component {
 
         const submitButton = 
             <ClassifierButton
-                disabled={R.keys(this.props.shapes).length < this.props.tools[0].min}
+                disabled={R.keys(this.props.shapes).length < tool.min}
                 onPress={this.submitClassification}
                 style={styles.submitButton}
                 type="answer"

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -8,21 +8,23 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import R from 'ramda'
+import DeviceInfo from 'react-native-device-info';
 
 import Theme from '../../theme'
 import ClassificationPanel from '../classifier/ClassificationPanel'
-import ImageWithSvgOverlay from './ImageWithSvgOverlay'
+import DrawingClassifierSubject from './DrawingClassifierSubject'
 import Question from '../classifier/Question'
 import Tutorial from '../classifier/Tutorial'
 import * as imageActions from '../../actions/images'
 import * as classifierActions from '../../actions/classifier'
+import * as navBarActions from '../../actions/navBar'
+import * as drawingActions from '../../actions/drawing'
 import ClassificationContainer from '../classifier/ClassifierContainer'
 import NeedHelpButton from '../classifier/NeedHelpButton'
 import OverlaySpinner from '../OverlaySpinner'
 import ClassifierButton from '../classifier/ClassifierButton'
 import Separator from '../common/Separator'
 import NavBar from '../NavBar'
-import * as navBarActions from '../../actions/navBar'
 import DrawingModal from './DrawingModal'
 import NativeImage from '../../nativeModules/NativeImage'
 import ShapeInstructionsView from './components/ShapeInstructionsView';
@@ -38,17 +40,19 @@ const mapStateToProps = (state, ownProps) => {
         tutorial: state.classifier.tutorial[ownProps.workflow.id] || {},
         needsTutorial: state.classifier.needsTutorial[ownProps.workflow.id] || false,
         subject: state.classifier.subject,
-        shapes: state.drawing.shapes,
+        shapes: DeviceInfo.isTablet() ? state.drawing.shapesInProgress : state.drawing.shapes,
         workflowOutOfSubjects: state.classifier.workflowOutOfSubjects,
         numberOfShapesDrawn: R.keys(state.drawing.shapesInProgress).length,
         subjectDimensions: subjectDimensions ? subjectDimensions : {naturalHeight: 1, naturalWidth: 1},
+        canUndo: state.drawing.actions.length > 0,
     }
 }
 
 const mapDispatchToProps = (dispatch) => ({
     imageActions: bindActionCreators(imageActions, dispatch),
     classifierActions: bindActionCreators(classifierActions, dispatch),
-    navBarActions: bindActionCreators(navBarActions, dispatch)
+    navBarActions: bindActionCreators(navBarActions, dispatch),
+    drawingActions: bindActionCreators(drawingActions, dispatch)
 })
 
 const PAGE_KEY = 'DrawingScreen'
@@ -93,7 +97,7 @@ class DrawingClassifier extends Component {
     }
 
     submitClassification() {
-        this.props.classifierActions.submitDrawingClassification(this.props.workflow, this.props.subject, this.state.subjectDimensions)
+        this.props.classifierActions.submitDrawingClassification(this.props.shapes, this.props.workflow, this.props.subject, this.state.subjectDimensions)
         this.setState({
             modalHasBeenClosedOnce: false,
             imageIsLoaded: false
@@ -106,10 +110,10 @@ class DrawingClassifier extends Component {
             this.props.imageActions.loadImageToCache(subject.display.src).then(localImagePath => {
                 new NativeImage(localImagePath).getImageSize().then(({width, height}) => {
                     this.props.classifierActions.setSubjectSizeInWorkflow(subject.id, {width, height})
-                })
-                this.setState({
-                    imageIsLoaded: true,
-                    localImagePath
+                    this.setState({
+                        imageIsLoaded: true,
+                        localImagePath
+                    })
                 })
             })
         }
@@ -141,6 +145,8 @@ class DrawingClassifier extends Component {
             return <OverlaySpinner overrideVisibility={this.props.isFetching} />
         }
 
+        // We validate that tools has at least one element earlier
+        const tool = this.props.tools[0]
         const warnForRequirements = this.state.modalHasBeenClosedOnce && R.keys(this.props.shapes).length < this.props.tools[0].min
 
         const tutorial =
@@ -163,13 +169,17 @@ class DrawingClassifier extends Component {
                     numberDrawn={this.props.numberOfShapesDrawn}
                     warnForRequirements={warnForRequirements}
                 />
-                <TouchableOpacity style={styles.container} onPress={() => this.setState({isModalVisible: true})}>
-                    <ImageWithSvgOverlay
-                        shapes={this.props.shapes}
+                <TouchableOpacity disabled={DeviceInfo.isTablet()} onPress={() => this.setState({isModalVisible: true})} style={styles.container} >
+                    <DrawingClassifierSubject
+                        showDrawingButtons={DeviceInfo.isTablet()}
+                        onUndoButtonSelected={this.props.drawingActions.undoMostRecentEdit}
+                        maxShapesDrawn={this.props.numberOfShapesDrawn >= tool.max}
+                        drawingColor={tool.color}
                         imageIsLoaded={this.state.imageIsLoaded}
-                        uri={this.state.localImagePath}
+                        imageSource={this.state.localImagePath}
+                        canUndo={this.props.canUndo}
                         onImageLayout={this.onImageLayout}
-                        showBlurView={R.isEmpty(this.props.shapes)}
+                        showBlurView={!DeviceInfo.isTablet() && R.isEmpty(this.props.shapes)}
                         alreadySeen={this.props.subject.already_seen}
                         subjectDimensions={this.props.subjectDimensions}
                         displayToNativeRatio={this.props.subjectDimensions.naturalWidth/this.state.subjectDimensions.clientWidth}
@@ -227,8 +237,7 @@ class DrawingClassifier extends Component {
                     {this.props.needsTutorial ? tutorial : classificationView}
                 </ClassificationContainer>
                 <DrawingModal
-                    // We validate that tools has at least one element earlier
-                    tool={this.props.tools[0]}
+                    tool={tool}
                     visible={this.state.isModalVisible} 
                     imageSource={this.state.localImagePath}
                     onClose={() => this.setState({isModalVisible: false, modalHasBeenClosedOnce: true})}
@@ -329,6 +338,10 @@ DrawingClassifier.propTypes = {
     subjectDimensions: PropTypes.shape({
         naturalHeight: PropTypes.number,
         naturalWidth: PropTypes.number
+    }),
+    canUndo: PropTypes.bool,
+    drawingActions: PropTypes.shape({
+        undoMostRecentEdit: PropTypes.func
     })
 }
 

--- a/src/components/Markings/DrawingModal.js
+++ b/src/components/Markings/DrawingModal.js
@@ -13,8 +13,7 @@ import R from 'ramda'
 import Theme from '../../theme'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import CloseButton from '../common/CloseButton'
-import MarkableImage from './components/MarkableImage'
-import DrawingButtons from './components/DrawingButtons'
+import DrawingToolView from './components/DrawingToolView'
 import InstructionView from './components/InstructionView'
 
 import * as drawingActions from '../../actions/drawing'
@@ -34,11 +33,6 @@ class DrawingModal extends Component {
     constructor(props) {
         super(props)
 
-        this.state = {
-            mode: 'draw'
-        }
-
-        this.handleDrawingButtonPress = this.handleDrawingButtonPress.bind(this)
         this.onCancel = this.onCancel.bind(this)
         this.onSave = this.onSave.bind(this)
     }
@@ -99,15 +93,11 @@ class DrawingModal extends Component {
                         <View style={ [styles.blurView, styles.androidBlurView] } />
                 }
                 <View style={styles.modalContainer}>
-                    <MarkableImage
-                        drawingColor={this.props.tool.color}
-                        source={this.props.imageSource}
-                        mode={this.state.mode}
+                    <DrawingToolView
+                        onUndoButtonSelected={this.props.drawingActions.undoMostRecentEdit}
                         maxShapesDrawn={this.props.numberOfShapesDrawn >= this.props.tool.max}
-                    />
-                    <DrawingButtons
-                        onButtonSelected={this.handleDrawingButtonPress}
-                        highlightedButton={this.state.mode}
+                        drawingColor={this.props.tool.color}
+                        imageSource={this.props.imageSource}
                         canUndo={this.props.canUndo}
                     />
                     <InstructionView

--- a/src/components/Markings/components/DrawingButton.js
+++ b/src/components/Markings/components/DrawingButton.js
@@ -6,16 +6,18 @@ import {
 import PropTypes from 'prop-types'
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5'
 import EStyleSheet from 'react-native-extended-stylesheet'
+import DeviceInfo from 'react-native-device-info';
+
 import Theme from '../../../theme'
 
-const RADIUS = 15
+const RADIUS = DeviceInfo.isTablet() ? 20 : 15
 export const DrawingButton = ({ style, activated, type, onPress, disabled }) => {
     const circleStyle = {
         width: RADIUS * 2,
         height: RADIUS * 2,
         borderRadius: RADIUS,
         backgroundColor: activated ? Theme.$zooniverseTeal : 'transparent',
-        borderWidth: 1,
+        borderWidth: DeviceInfo.isTablet() ? 2 : 1,
         borderColor: Theme.$zooniverseTeal
     }
 

--- a/src/components/Markings/components/DrawingButtons.js
+++ b/src/components/Markings/components/DrawingButtons.js
@@ -12,25 +12,25 @@ const DrawingButtons = (props) => {
                 disabled={!props.canUndo}
                 type="undo"
                 activated={false}
-                onPress={() => props.onButtonSelected('undo')}
+                onPress={() => props.onUndoButtonSelected()}
             />
             <View style={styles.drawingButtonsContainer}>
                 <DrawingButton 
                     style={styles.buttonPadding}
                     type="draw"
                     activated={props.highlightedButton === 'draw'}
-                    onPress={() => props.onButtonSelected('draw')}
+                    onPress={() => props.onModeButtonSelected('draw')}
                 />
                 <DrawingButton 
                     style={styles.buttonPadding}
                     type="edit"
                     activated={props.highlightedButton === 'edit'}
-                    onPress={() => props.onButtonSelected('edit')}
+                    onPress={() => props.onModeButtonSelected('edit')}
                 />
                 <DrawingButton
                     type="erase"
                     activated={props.highlightedButton === 'erase'}
-                    onPress={() => props.onButtonSelected('erase')}
+                    onPress={() => props.onModeButtonSelected('erase')}
                 />
             </View>
         </View>
@@ -54,7 +54,8 @@ const styles = {
 }
 
 DrawingButtons.propTypes = {
-    onButtonSelected: PropTypes.func,
+    onModeButtonSelected: PropTypes.func,
+    onUndoButtonSelected: PropTypes.func,
     highlightedButton: PropTypes.oneOf(['draw', 'edit', 'erase', 'unselected']),
     canUndo: PropTypes.bool
 }

--- a/src/components/Markings/components/DrawingToolView.js
+++ b/src/components/Markings/components/DrawingToolView.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react'
+import {
+    Animated,
+    View
+} from 'react-native'
+import PropTypes from 'prop-types'
+
+import MarkableImage from './MarkableImage'
+import DrawingButtons from './DrawingButtons'
+import SubjectLoadingIndicator from '../../common/SubjectLoadingIndicator'
+
+class DrawingToolView extends Component {
+    
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            scale: new Animated.Value(1),
+            mode: 'draw'
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.imageIsLoaded !== this.props.imageIsLoaded) {
+            if (!this.props.imageIsLoaded) {
+                this.setState({scale: new Animated.Value(0.8)})
+            } else {
+                this.animateScale()
+            }
+        }
+    }
+
+    animateScale() {
+        Animated.spring(
+            this.state.scale,
+            {
+                toValue: 1
+            }
+        ).start()
+    }
+    
+    render() {
+        return (
+            <View style={styles.container}>
+                {
+                    this.props.imageIsLoaded ? 
+                        <Animated.View style={[styles.container, {transform: [{scale: this.state.scale}]}]} >
+                            <MarkableImage
+                                onContainerLayout={this.props.onContainerLayout}
+                                drawingColor={this.props.drawingColor}
+                                source={this.props.imageSource}
+                                mode={this.state.mode}
+                                maxShapesDrawn={this.props.maxShapesDrawn}
+                                canDraw={this.props.canDraw}
+                            />
+                        </Animated.View>
+                    :
+                        <SubjectLoadingIndicator />
+                }
+                {
+                    this.props.showDrawingButtons && 
+                        <DrawingButtons
+                            onUndoButtonSelected={this.props.onUndoButtonSelected}
+                            onModeButtonSelected={buttonType => this.setState({mode: buttonType})}
+                            highlightedButton={this.state.mode}
+                            canUndo={this.props.canUndo}
+                        />
+                }
+            </View>
+        )
+    }
+}
+
+const styles = {
+    container: {flex: 1}
+}
+
+DrawingToolView.propTypes = {
+    maxShapesDrawn: PropTypes.bool,
+    drawingColor: PropTypes.string,
+    imageSource: PropTypes.string,
+    canUndo: PropTypes.bool,
+    onUndoButtonSelected: PropTypes.func,
+    onContainerLayout: PropTypes.func,
+    showDrawingButtons: PropTypes.bool,
+    imageIsLoaded: PropTypes.bool,
+    animateImage: PropTypes.func,
+    canDraw: PropTypes.bool
+}
+
+DrawingToolView.defaultProps = {
+    imageIsLoaded: true,
+    showDrawingButtons: true,
+    canDraw: true
+}
+
+export default DrawingToolView

--- a/src/components/Markings/components/InstructionView.js
+++ b/src/components/Markings/components/InstructionView.js
@@ -4,8 +4,8 @@ import {
     View
 } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet'
-
 import PropTypes from 'prop-types'
+
 import FontedText from '../../common/FontedText'
 import Separator from '../../common/Separator'
 import ShapeInstructionsView from './ShapeInstructionsView'

--- a/src/components/Markings/components/MarkableImage.js
+++ b/src/components/Markings/components/MarkableImage.js
@@ -59,6 +59,14 @@ class MarkableImage extends Component {
         const aspectRatio = Math.min(containerHeight/naturalHeight, containerWidth/naturalWidth)
         const clientHeight = naturalHeight * aspectRatio
         const clientWidth = naturalWidth * aspectRatio
+        
+        if (this.props.onContainerLayout) {
+            this.props.onContainerLayout({
+                height: clientHeight,
+                width: clientWidth,
+            })
+        }
+
         this.setState({
             isImageLoaded: true,
             clientHeight,
@@ -80,6 +88,7 @@ class MarkableImage extends Component {
                     {
                         this.state.isImageLoaded ? 
                             <SvgOverlay
+                                canDraw={this.props.canDraw}
                                 nativeWidth={naturalWidth}
                                 nativeHeight={naturalHeight}
                                 shapes={this.props.shapes}
@@ -130,6 +139,8 @@ MarkableImage.propTypes = {
         mutateShapeAtIndex: PropTypes.func
     }),
     source: PropTypes.string,
+    onContainerLayout: PropTypes.func,
+    canDraw: PropTypes.bool
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarkableImage)

--- a/src/components/Markings/components/ShapeInstructionsView.js
+++ b/src/components/Markings/components/ShapeInstructionsView.js
@@ -2,9 +2,11 @@ import React from 'react'
 import {
     View
 } from 'react-native'
-import FontedText from '../../common/FontedText'
 import PropTypes from 'prop-types'
 import EStyleSheet from 'react-native-extended-stylesheet'
+import DeviceInfo from 'react-native-device-info'
+
+import FontedText from '../../common/FontedText'
 
 const ShapeInstructionsView = (props) => {
     const warningStyle = props.warnForRequirements ? styles.warningText : {}
@@ -68,10 +70,10 @@ const styles = EStyleSheet.create({
     },
     label: {
         fontWeight: 'bold',
-        fontSize: 14,
+        fontSize: DeviceInfo.isTablet() ? 22 : 14,
     },
     infoText: {
-        fontSize: 14,
+        fontSize: DeviceInfo.isTablet() ? 22 : 14,
         color: '$headerGrey'
     },
     warningText: {

--- a/src/components/Markings/components/SvgOverlay.js
+++ b/src/components/Markings/components/SvgOverlay.js
@@ -45,10 +45,10 @@ class SvgOverlay extends Component {
 
         this.panResponder = PanResponder.create({
             // Ask to be the responder:
-            onStartShouldSetPanResponder: () => this.props.mode === 'draw' && !this.props.maxShapesDrawn,
-            onStartShouldSetPanResponderCapture: () => this.props.mode === 'draw' && !this.props.maxShapesDrawn,
-            onMoveShouldSetPanResponder: () => this.props.mode === 'draw' && !this.props.maxShapesDrawn,
-            onMoveShouldSetPanResponderCapture: () => this.props.mode === 'draw' && !this.props.maxShapesDrawn,
+            onStartShouldSetPanResponder: () => this.props.canDraw && this.props.mode === 'draw' && !this.props.maxShapesDrawn,
+            onStartShouldSetPanResponderCapture: () => this.props.canDraw && this.props.mode === 'draw' && !this.props.maxShapesDrawn,
+            onMoveShouldSetPanResponder: () => this.props.canDraw && this.props.mode === 'draw' && !this.props.maxShapesDrawn,
+            onMoveShouldSetPanResponderCapture: () => this.props.canDraw && this.props.mode === 'draw' && !this.props.maxShapesDrawn,
             onPanResponderGrant: (evt) => {
                 const { locationX, locationY } = evt.nativeEvent
                 this.setState({
@@ -207,7 +207,8 @@ SvgOverlay.propTypes = {
     mode: PropTypes.oneOf(['draw', 'edit', 'erase', 'unselected']),
     onShapeDeleted: PropTypes.func,
     onShapeCreated: PropTypes.func,
-    onShapeModified: PropTypes.func
+    onShapeModified: PropTypes.func,
+    canDraw: PropTypes.bool
 }
 
 SvgOverlay.defaultProps = {

--- a/src/components/classifier/ClassificationPanel.js
+++ b/src/components/classifier/ClassificationPanel.js
@@ -3,6 +3,7 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
+import DeviceInfo from 'react-native-device-info'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import FontedText from '../common/FontedText'
 import PropTypes from 'prop-types';
@@ -67,6 +68,7 @@ const styles = EStyleSheet.create({
     backgroundColor: '$lightestGrey',
   },
   tabText: {
+    fontSize: DeviceInfo.isTablet() ? 22 : 14,
     marginVertical: 15
   }
 })

--- a/src/components/classifier/ClassificationPanel.js
+++ b/src/components/classifier/ClassificationPanel.js
@@ -30,7 +30,7 @@ class ClassificationPanel extends Component {
 
     return (
       <View style={styles.container}>
-        <View style={[styles.panelContainer, this.props.isQuestionVisible ? styles.questionMargin : styles.tutorialMargin]}>
+        <View style={styles.panelContainer}>
           { this.props.hasTutorial ? tabs : null }
           { this.props.children }
         </View>
@@ -52,12 +52,6 @@ const styles = EStyleSheet.create({
     marginTop: 15,
     marginBottom: 0,
     marginHorizontal: 25
-  },
-  questionMargin: {
-    marginHorizontal: 25
-  },
-  tutorialMargin: {
-    marginHorizontal: 0
   },
   tabContainer: {
     flexDirection: 'row',

--- a/src/components/classifier/ClassificationPanel.js
+++ b/src/components/classifier/ClassificationPanel.js
@@ -30,7 +30,7 @@ class ClassificationPanel extends Component {
 
     return (
       <View style={styles.container}>
-        <View style={styles.panelContainer}>
+        <View style={[styles.panelContainer, this.props.isQuestionVisible ? styles.questionMargin : styles.tutorialMargin]}>
           { this.props.hasTutorial ? tabs : null }
           { this.props.children }
         </View>
@@ -52,6 +52,12 @@ const styles = EStyleSheet.create({
     marginTop: 15,
     marginBottom: 0,
     marginHorizontal: 25
+  },
+  questionMargin: {
+    marginHorizontal: 25
+  },
+  tutorialMargin: {
+    marginHorizontal: 0
   },
   tabContainer: {
     flexDirection: 'row',

--- a/src/components/classifier/ClassifierButton.js
+++ b/src/components/classifier/ClassifierButton.js
@@ -43,7 +43,7 @@ const styles =EStyleSheet.create({
         justifyContent: 'center',
       },
       buttonText: {
-        fontSize: DeviceInfo.isTablet ? 22 : 14,
+        fontSize: DeviceInfo.isTablet() ? 22 : 14,
         marginVertical: 11,
         marginHorizontal: 9
       },

--- a/src/components/classifier/ClassifierButton.js
+++ b/src/components/classifier/ClassifierButton.js
@@ -3,9 +3,11 @@ import {
     StyleSheet,
     TouchableOpacity
 } from 'react-native'
-import FontedText from '../common/FontedText'
 import PropTypes from 'prop-types'
 import EStyleSheet from 'react-native-extended-stylesheet'
+import DeviceInfo from 'react-native-device-info'
+
+import FontedText from '../common/FontedText'
 
 const ClassifierButton = (props) => {
     const buttonStyle = [props.style, styles.button]
@@ -41,6 +43,7 @@ const styles =EStyleSheet.create({
         justifyContent: 'center',
       },
       buttonText: {
+        fontSize: DeviceInfo.isTablet ? 22 : 14,
         marginVertical: 11,
         marginHorizontal: 9
       },

--- a/src/components/classifier/NeedHelpButton.js
+++ b/src/components/classifier/NeedHelpButton.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {
     TouchableOpacity
 } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
 import FontedText from '../common/FontedText'
 import PropTypes from 'prop-types'
 
@@ -21,6 +22,7 @@ NeedHelpButton.propTypes = {
 
 const styles = {
     needHelpText: {
+        fontSize: DeviceInfo.isTablet() ? 22 : 14,
         textAlign: 'center',
         marginTop: 15,
         color: 'rgba(0,93,105,1)'

--- a/src/components/classifier/Question.js
+++ b/src/components/classifier/Question.js
@@ -9,6 +9,8 @@ import EStyleSheet from 'react-native-extended-stylesheet'
 import PropTypes from 'prop-types';
 import Markdown from 'react-native-simple-markdown'
 import { connect } from 'react-redux'
+import DeviceInfo from 'react-native-device-info'
+
 import { setQuestionContainerHeight } from '../../actions/classifier'
 import {
   extractFirstLinkedImageFrom,
@@ -48,7 +50,7 @@ export class Question extends Component {
       <View style={[styles.questionContainer]}>
         <View style={styles.question}>
           <View style={styles.markdown}>
-            <Markdown>
+            <Markdown styles={markdownStyles}>
               {this.state.question}
             </Markdown>
           </View>
@@ -70,6 +72,12 @@ export class Question extends Component {
         </View>
       </View>
     )
+  }
+}
+
+const markdownStyles = {
+  text: {
+    fontSize: DeviceInfo.isTablet() ? 22 : 14
   }
 }
 

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -12,10 +12,6 @@ import Swiper from 'react-native-swiper';
 import { addIndex, length, map } from 'ramda'
 import PropTypes from 'prop-types';
 
-import StyledText from '../StyledText'
-import Button from '../Button'
-import TutorialStep from './TutorialStep'
-
 import Button from '../Button'
 import TutorialStep from './TutorialStep'
 import FontedText from '../common/FontedText';
@@ -33,7 +29,6 @@ export class Tutorial extends Component {
   render() {
     const steps = this.props.tutorial.steps
     const totalSteps = length(steps)
-    
     const tutorialSteps = steps.map((step, index) => {
       return (
         <TutorialStep
@@ -204,6 +199,10 @@ const styles = EStyleSheet.create({
     paddingTop: topPadding,
     paddingBottom: 0,
   },
+  markdown: {
+    flex: 1,
+    marginTop: 15
+  }
 })
 
 Tutorial.propTypes = {

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -16,6 +16,10 @@ import StyledText from '../StyledText'
 import Button from '../Button'
 import TutorialStep from './TutorialStep'
 
+import Button from '../Button'
+import TutorialStep from './TutorialStep'
+import FontedText from '../common/FontedText';
+
 const topPadding = (Platform.OS === 'ios') ? 10 : 0
 
 export class Tutorial extends Component {
@@ -103,9 +107,9 @@ export class Tutorial extends Component {
         text={'Let\s Go!'} />
 
     const tutorialHeader =
-      <StyledText
-        text={`${this.props.projectName} - Tutorial`}
-        additionalStyles={[styles.tutorialHeader]}/>
+      <FontedText style={styles.tutorialHeader}>
+        {`${this.props.projectName} - Tutorial`}
+      </FontedText>
 
     return (
       <View style={styles.container}>

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -6,6 +6,10 @@ import {
 } from 'react-native'
 import PropTypes from 'prop-types'
 import Markdown from 'react-native-simple-markdown'
+<<<<<<< HEAD
+=======
+import DeviceInfo from 'react-native-device-info'
+>>>>>>> Add dynamic sizing for tablet
 
 import FittedImage from '../common/FittedImage' 
 
@@ -46,7 +50,7 @@ class TutorialStep extends Component {
                         }
 
                         <View style={styles.markdown} >
-                            <Markdown >
+                            <Markdown styles={markdownStyles}>
                                 { this.props.markdownContent }
                             </Markdown>
                         </View>
@@ -56,6 +60,12 @@ class TutorialStep extends Component {
         )
     }
 }
+
+const markdownStyles = {
+    text: {
+      fontSize: DeviceInfo.isTablet() ? 22 : 14
+    }
+  }
 
 const styles = {
     markdown: {

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -6,10 +6,7 @@ import {
 } from 'react-native'
 import PropTypes from 'prop-types'
 import Markdown from 'react-native-simple-markdown'
-<<<<<<< HEAD
-=======
 import DeviceInfo from 'react-native-device-info'
->>>>>>> Add dynamic sizing for tablet
 
 import FittedImage from '../common/FittedImage' 
 
@@ -65,7 +62,7 @@ const markdownStyles = {
     text: {
       fontSize: DeviceInfo.isTablet() ? 22 : 14
     }
-  }
+}
 
 const styles = {
     markdown: {

--- a/src/components/classifier/__tests__/__snapshots__/ClassificationPanel-test.js.snap
+++ b/src/components/classifier/__tests__/__snapshots__/ClassificationPanel-test.js.snap
@@ -5,12 +5,7 @@ exports[`renders correctly 1`] = `
   style={undefined}
 >
   <View
-    style={
-      Array [
-        undefined,
-        undefined,
-      ]
-    }
+    style={undefined}
   />
 </View>
 `;

--- a/src/components/classifier/__tests__/__snapshots__/ClassificationPanel-test.js.snap
+++ b/src/components/classifier/__tests__/__snapshots__/ClassificationPanel-test.js.snap
@@ -5,7 +5,12 @@ exports[`renders correctly 1`] = `
   style={undefined}
 >
   <View
-    style={undefined}
+    style={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
   />
 </View>
 `;

--- a/src/components/classifier/__tests__/__snapshots__/Question-test.js.snap
+++ b/src/components/classifier/__tests__/__snapshots__/Question-test.js.snap
@@ -14,7 +14,15 @@ exports[`renders correctly (without task help) 1`] = `
     <View
       style={undefined}
     >
-      <Markdown>
+      <Markdown
+        styles={
+          Object {
+            "text": Object {
+              "fontSize": 14,
+            },
+          }
+        }
+      >
         Is this this?
       </Markdown>
     </View>
@@ -36,7 +44,15 @@ exports[`renders correctly with task help 1`] = `
     <View
       style={undefined}
     >
-      <Markdown>
+      <Markdown
+        styles={
+          Object {
+            "text": Object {
+              "fontSize": 14,
+            },
+          }
+        }
+      >
         Is this this?
       </Markdown>
     </View>

--- a/src/components/classifier/__tests__/__snapshots__/Tutorial-test.js.snap
+++ b/src/components/classifier/__tests__/__snapshots__/Tutorial-test.js.snap
@@ -73,7 +73,15 @@ exports[`renders correctly 1`] = `
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   ### Welcome to Planet Four: Ridges
 ----------
 This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
@@ -145,7 +153,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
 
 
@@ -217,7 +233,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
                 </Markdown>
               </View>
@@ -506,10 +530,10 @@ exports[`renders header if initial tutorial 1`] = `
     ellipsizeMode="tail"
     style={
       Array [
+        Object {
+          "fontFamily": "Karla",
+        },
         undefined,
-        Array [
-          undefined,
-        ],
       ]
     }
   >
@@ -584,7 +608,15 @@ exports[`renders header if initial tutorial 1`] = `
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   ### Welcome to Planet Four: Ridges
 ----------
 This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
@@ -656,7 +688,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
 
 
@@ -728,7 +768,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
                 </Markdown>
               </View>
@@ -1051,7 +1099,15 @@ exports[`renders with no media 1`] = `
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   ### Welcome to Planet Four: Ridges
 ----------
 This brief tutorial will teach you how to discover polygonal ridges on Mars. By mapping these features, you are helping to explore Mars' past. 
@@ -1094,7 +1150,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   You will be presented with a cutout from an image taken by the Context Camera aboard Mars Reconnaissance Orbiter. All you need to do is spot the polygonal ridges, if any are present in the image. 
 
 
@@ -1137,7 +1201,15 @@ This brief tutorial will teach you how to discover polygonal ridges on Mars. By 
                   }
                 }
               >
-                <Markdown>
+                <Markdown
+                  styles={
+                    Object {
+                      "text": Object {
+                        "fontSize": 14,
+                      },
+                    }
+                  }
+                >
                   Polygonal ridges are intersecting, creating spider-web like patterns. Notice how the ridges intersect to form closed shapes of varying sizes. 
                 </Markdown>
               </View>


### PR DESCRIPTION
# Description

There are a few things going on here:

1) Dynamicaly Size Text for Android
	- Add `react-native-device-info` this package lets us check if the device is a tabler
	- Add Dynamic sizing for text in the classifier and tutorial

2) Remove drawing modal for tablet
	- We removed the modal because we don't need to create additional space on tablet.

3) Various layout and formatting fixes
	- Fixed an issue with tutorial margins
	- Fixed a bug where the field guide always show on the drawing task


# Review checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

