### PR TITLE
Move question button

### DIFF
--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -281,7 +281,6 @@ const styles = EStyleSheet.create({
     },
     fieldGuideContainer: {
         marginHorizontal: 25,
-        marginTop: 15
     },
     fieldGuideButton: {
         height: 40

--- a/src/components/classifier/NeedHelpButton.js
+++ b/src/components/classifier/NeedHelpButton.js
@@ -24,7 +24,7 @@ const styles = {
     needHelpText: {
         fontSize: DeviceInfo.isTablet() ? 22 : 14,
         textAlign: 'center',
-        marginTop: 15,
+        marginVertical: 15,
         color: 'rgba(0,93,105,1)'
     }
 }

--- a/src/components/classifier/SwipeClassifier.js
+++ b/src/components/classifier/SwipeClassifier.js
@@ -240,8 +240,8 @@ export class SwipeClassifier extends React.Component {
           { this.state.isQuestionVisible ? classification : tutorial }
           { this.state.isQuestionVisible ? unlinkedTask :null }
         </ClassificationPanel>
-        { this.state.isQuestionVisible && this.props.task.help ? <NeedHelpButton onPress={() => this.classifierContainer.displayHelpModal()} /> : null }
         { this.state.isQuestionVisible ? swipeTabs : null }
+        { this.state.isQuestionVisible && this.props.task.help ? <NeedHelpButton onPress={() => this.classifierContainer.displayHelpModal()} /> : null }
         <FullScreenImage
           source={{uri: this.state.fullScreenImageSource}}
           isVisible={this.state.showFullSize}

--- a/src/components/classifier/SwipeTabs.js
+++ b/src/components/classifier/SwipeTabs.js
@@ -60,6 +60,7 @@ const styles = EStyleSheet.create({
   container: {
     marginHorizontal: 25,
     marginTop: 15,
+    marginBottom: 5,
     backgroundColor: 'transparent',
     flexDirection: 'row',
     justifyContent: 'space-around'


### PR DESCRIPTION
This is something that came up on the mobile slack channel a couple of weeks ago. Essentially the thought was that the swipe answer buttons look like answers to the  'Need Some Help?' text button.

So the decision was to move the buttons above the help text button.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

