### PR TITLE
Issue229

### DIFF
--- a/src/components/Markings/components/ShapeEditorSvg.js
+++ b/src/components/Markings/components/ShapeEditorSvg.js
@@ -60,7 +60,7 @@ class ShapeEditorSvg extends Component {
                 bottomRight: false,
                 upperLeft: false,
                 upperRight: false,
-                permiterOnly: false
+                perimeterOnly: false
             },
             shapeRefs: {},
             isDrawing: false,
@@ -128,7 +128,7 @@ class ShapeEditorSvg extends Component {
                     const deltas = calculateShapeChanges(touchState, dx, dy, this.props.displayToNativeRatioX, this.props.displayToNativeRatioY)
                     const newDimensions = shapeRefs[shapeIndex].update(deltas);
                     const shapeIsOutOfBounds = isShapeOutOfBounds(newDimensions, {width: this.props.width *this.props.displayToNativeRatioX, height: this.props.height * this.props.displayToNativeRatioY})
-                    const shapeIsOutOfBoundsAndBeingDragged = shapeIsOutOfBounds && touchState.permiterOnly
+                    const shapeIsOutOfBoundsAndBeingDragged = shapeIsOutOfBounds && touchState.perimeterOnly
                     this.props.onShapeIsOutOfBoundsUpdates(shapeIsOutOfBoundsAndBeingDragged)
                     this.setState({
                         shapeToRemoveIndex: shapeIsOutOfBoundsAndBeingDragged ? shapeIndex : -1
@@ -155,7 +155,7 @@ class ShapeEditorSvg extends Component {
                 const { shapeIndex, touchState, isDrawing, shapeToRemoveIndex } = this.state
 
                 // Remove a shape if the user has dragged it off screen
-                if (shapeToRemoveIndex >= 0 && touchState.permiterOnly) { 
+                if (shapeToRemoveIndex >= 0 && touchState.perimeterOnly) { 
                     this.deleteShapeWithKey(shapeToRemoveIndex)
                 }
                 // If the user is editing a shape, update the shape changes 
@@ -200,7 +200,7 @@ class ShapeEditorSvg extends Component {
                 bottomRight: false,
                 upperLeft: false,
                 upperRight: false,
-                permiterOnly: false
+                perimeterOnly: false
             }
         })
     }

--- a/src/utils/shapeUtils.js
+++ b/src/utils/shapeUtils.js
@@ -83,7 +83,7 @@ const analyzeCorners = (xCoord, yCoord, corners) => {
  *  bottomLeft: true,
  *  bottomRight: false,
  *  withinSquare: true,
- *  permiterOnly: false
+ *  perimeterOnly: false
  * }
  * 
  * This object essentially explains which part of the shape the user is touching
@@ -101,7 +101,7 @@ export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
     return {
         ... analyzedCorners,
         withinSquare,
-        permiterOnly: !touchingCorners && touchingPerimeter
+        perimeterOnly: !touchingCorners && touchingPerimeter
     }
 }
 
@@ -116,12 +116,12 @@ export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
  * @param {The ratio that the shape should scale in the y direction} scaleRatioY 
  */
 export const calculateShapeChanges = (touchState, touchDx, touchDy, scaleRatioX, scaleRatioY) => {
-    const {upperLeft, bottomLeft, upperRight, bottomRight, permiterOnly} = touchState
+    const {upperLeft, bottomLeft, upperRight, bottomRight, perimeterOnly} = touchState
     const scaledX = touchDx * scaleRatioX
     const scaledY = touchDy * scaleRatioY
 
     let dx = 0, dy = 0, dw = 0, dh = 0
-    if (permiterOnly) {
+    if (perimeterOnly) {
         dx = scaledX
         dy = scaledY
     } else if (upperLeft) {

--- a/src/utils/shapeUtils.js
+++ b/src/utils/shapeUtils.js
@@ -1,4 +1,11 @@
 import R from 'ramda'
+export const drawingTouchState = {
+    perimeterOnly: false,
+    upperLeft: false,
+    bottomLeft: false,
+    upperRight: false,
+    bottomRight: true
+}
 
 /**
  * This function receives and x,y coordinate and determines if

--- a/src/utils/shapeUtils.js
+++ b/src/utils/shapeUtils.js
@@ -1,4 +1,8 @@
 import R from 'ramda'
+import {
+    distanceFromRange
+} from './drawingUtils'
+
 export const drawingTouchState = {
     perimeterOnly: false,
     upperLeft: false,
@@ -122,37 +126,81 @@ export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
  * @param {The ratio that the shape should scale in the x direction} scaleRatioX 
  * @param {The ratio that the shape should scale in the y direction} scaleRatioY 
  */
-export const calculateShapeChanges = (touchState, touchDx, touchDy, scaleRatioX, scaleRatioY) => {
+export const calculateShapeChanges = (  touchState, touchDx, touchDy, scaleRatioX, 
+                                        scaleRatioY, shapeCoordinates, svgWidth, svgHeight,
+                                        dragOrigin ) => {
     const {upperLeft, bottomLeft, upperRight, bottomRight, perimeterOnly} = touchState
     const scaledX = touchDx * scaleRatioX
     const scaledY = touchDy * scaleRatioY
 
-    let dx = 0, dy = 0, dw = 0, dh = 0
-    if (perimeterOnly) {
-        dx = scaledX
-        dy = scaledY
-    } else if (upperLeft) {
-        dx = scaledX
-        dy = scaledY
-        dw = -scaledX
-        dh = -scaledY
-    } else if (bottomLeft) {
-        dx = scaledX
-        dw = -scaledX
-        dh = scaledY
-    } else if (upperRight) {
-        dy = scaledY
-        dw = scaledX
-        dh = -scaledY
-    } else if (bottomRight) {
-        dw = scaledX
-        dh = scaledY
+    const deltas = {
+        dx: 0,
+        dy: 0,
+        dw: 0,
+        dh: 0
     }
 
-    return {
-        dx,
-        dy,
-        dw,
-        dh
+    if (perimeterOnly) {
+        deltas.dx = scaledX
+        deltas.dy = scaledY
+    } else if (upperLeft) {
+        deltas.dx = scaledX
+        deltas.dy = scaledY
+        deltas.dw = -scaledX
+        deltas.dh = -scaledY
+    } else if (bottomLeft) {
+        deltas.dx = scaledX
+        deltas.dw = -scaledX
+        deltas.dh = scaledY
+    } else if (upperRight) {
+        deltas.dy = scaledY
+        deltas.dw = scaledX
+        deltas.dh = -scaledY
+    } else if (bottomRight) {
+        deltas.dw = scaledX
+        deltas.dh = scaledY
     }
+
+    return constrainDeltasToRange(  touchState, deltas, shapeCoordinates,
+                                    svgWidth * scaleRatioX, svgHeight * scaleRatioY,
+                                    { x: dragOrigin.x * scaleRatioX, y: dragOrigin.y * scaleRatioY } )
+}
+
+/**
+ * This function constrains a change in a shape to 2d bounds
+ * @param {Where the user is touching} touchState 
+ * @param {Proposed Deltas to a shape} deltas 
+ * @param {Shape coordinates} shapeCoordinates 
+ * @param {X bound} maxX 
+ * @param {Y bound} maxY 
+ * @param {Where the drag event originated} dragOrigin
+ */
+const constrainDeltasToRange = (touchState, deltas, shapeCoordinates, maxX, maxY, dragOrigin) => {
+    const { upperLeft, bottomLeft, upperRight, bottomRight } = touchState
+    const { dx, dy, dw, dh } = deltas 
+    const { x, y, height, width } = shapeCoordinates
+
+    const xIsOutOfRange = distanceFromRange(dragOrigin.x, 0, maxX) !== 0
+    const yIsOutOfRange = distanceFromRange(dragOrigin.y, 0, maxY) !== 0
+
+    const constrainedDeltas = { dx, dy, dw, dh }
+    if (xIsOutOfRange) {
+        const isXInverted = width + dw < 0 
+        if (upperLeft || bottomLeft) {
+            constrainedDeltas.dx = (isXInverted ? maxX : 0) - x
+            constrainedDeltas.dw = -constrainedDeltas.dx
+        }
+        if (upperRight || bottomRight) constrainedDeltas.dw = (isXInverted ? 0 : maxX) - (x + width)
+    }
+
+    if (yIsOutOfRange) {
+        const isYInverted = height + dh < 0
+        if (upperLeft || upperRight) {
+            constrainedDeltas.dy = (isYInverted ? maxY : 0) - y
+            constrainedDeltas.dh = -constrainedDeltas.dy
+        }
+        if (bottomLeft || bottomRight) constrainedDeltas.dh = (isYInverted ? 0 : maxY) - (y + height)
+    }
+
+    return constrainedDeltas
 }


### PR DESCRIPTION
Fixes #229 .

### Changes
Slight overhaul of how we calculate out of bounds to make up for some quarks with Android. Otherwise, user should not be able to draw or resize shapes out of bounds.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

