### PR TITLE
Just grab the file type, no parameters

### DIFF
--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -9,10 +9,10 @@ export const removeLeftOverImages = imageDictionary => {
 
 export const loadRemoteImageToCache = (remoteUri) => {
     return new Promise((resolve, reject) => {
-        const fileExtension = remoteUri.split('.').pop();
+        const appendExt = remoteUri.split('.').pop().split('?')[0];
         const task = RNFetchBlob.config({
                         fileCache: true,
-                        appendExt: fileExtension
+                        appendExt
                     })
                     .fetch('GET', remoteUri)
 


### PR DESCRIPTION
Fixes bug noted [here](https://www.zooniverse.org/talk/739/910315?comment=1509585&page=1)

The changes are pretty simple: 
 The code was assuming that between the last period and the end of an image url would be the extension like so: 

`https://www.imagehost.image.jpeg`

However, the code fails if the image url has parameters.

`https://www.imagehost.image.jpeg?height=256;width=256`.

So the new code change just scrubs out the parameters

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

