### PR TITLE
Navigate to separate components for single and multiple answer questions

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -113,12 +113,10 @@ const getAvatarsForProjects = projects => {
 const getWorkflowsForProjects = projects => {            
     const projectIds = projects.map((project) => project.id)
 
-    // TODO: change the literal list in the next line to projectIds
-    return apiClient.type('workflows').get({active: true, project_id: [1878,1877,302,514,523]})
+    return apiClient.type('workflows').get({active: true, project_id: projectIds})
     .then(workflows => {
         workflows.forEach( workflow => {
-            // TODO: change below to workflow.mobile_friendly && isValidMobileWorkflow(workflow) upon panoptes change
-            workflow.mobile_verified = isValidMobileWorkflow(workflow)
+            workflow.mobile_verified = workflow.mobile_friendly && isValidMobileWorkflow(workflow)
             const project = projects.find( project => project.id === workflow.links.project )
             if (!project.workflows.find((projectWorkflow) => projectWorkflow.id === workflow.id)) {
                 project.workflows = R.append(workflow, project.workflows)

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -6,7 +6,7 @@ import * as ActionConstants from '../constants/actions'
 import { isValidMobileWorkflow } from '../utils/workflow-utils'
 
 const productionParams = {
-    mobile_friendly: true,
+    // mobile_friendly: true,
     launch_approved: true,
     live: true,
     include: 'avatar',
@@ -14,7 +14,7 @@ const productionParams = {
 }
 
 const betaParams = {
-    mobile_friendly: true,
+    // mobile_friendly: true,
     beta_approved: true,
     include: 'avatar',
     sort: 'display_name',
@@ -22,7 +22,7 @@ const betaParams = {
 }
 
 const ownerParams = {
-    mobile_friendly: true,
+    // mobile_friendly: true,
     live: false,
     include: 'avatar',
     sort: 'display_name',
@@ -30,7 +30,7 @@ const ownerParams = {
 }
 
 const collaboratorParams = {
-    mobile_friendly: true,
+    // mobile_friendly: true,
     live: false,
     include: 'avatar',
     sort: 'display_name',
@@ -112,10 +112,13 @@ const getAvatarsForProjects = projects => {
 
 const getWorkflowsForProjects = projects => {            
     const projectIds = projects.map((project) => project.id)
-    return apiClient.type('workflows').get({mobile_friendly: true, active: true, project_id: projectIds})
+
+    // TODO: change the literal list in the next line to projectIds
+    return apiClient.type('workflows').get({active: true, project_id: [1878,1877,302,514,523]})
     .then(workflows => {
         workflows.forEach( workflow => {
-            workflow.mobile_verified = workflow.mobile_friendly && isValidMobileWorkflow(workflow)
+            // TODO: change below to workflow.mobile_friendly && isValidMobileWorkflow(workflow) upon panoptes change
+            workflow.mobile_verified = isValidMobileWorkflow(workflow)
             const project = projects.find( project => project.id === workflow.links.project )
             if (!project.workflows.find((projectWorkflow) => projectWorkflow.id === workflow.id)) {
                 project.workflows = R.append(workflow, project.workflows)

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -113,7 +113,7 @@ const getAvatarsForProjects = projects => {
 const getWorkflowsForProjects = projects => {            
     const projectIds = projects.map((project) => project.id)
 
-    return apiClient.type('workflows').get({active: true, project_id: projectIds})
+    return apiClient.type('workflows').get({mobile_friendly: true, active: true, project_id: projectIds})
     .then(workflows => {
         workflows.forEach( workflow => {
             workflow.mobile_verified = workflow.mobile_friendly && isValidMobileWorkflow(workflow)

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -6,7 +6,7 @@ import * as ActionConstants from '../constants/actions'
 import { isValidMobileWorkflow } from '../utils/workflow-utils'
 
 const productionParams = {
-    // mobile_friendly: true,
+    mobile_friendly: true,
     launch_approved: true,
     live: true,
     include: 'avatar',
@@ -14,7 +14,7 @@ const productionParams = {
 }
 
 const betaParams = {
-    // mobile_friendly: true,
+    mobile_friendly: true,
     beta_approved: true,
     include: 'avatar',
     sort: 'display_name',
@@ -22,7 +22,7 @@ const betaParams = {
 }
 
 const ownerParams = {
-    // mobile_friendly: true,
+    mobile_friendly: true,
     live: false,
     include: 'avatar',
     sort: 'display_name',
@@ -30,7 +30,7 @@ const ownerParams = {
 }
 
 const collaboratorParams = {
-    // mobile_friendly: true,
+    mobile_friendly: true,
     live: false,
     include: 'avatar',
     sort: 'display_name',

--- a/src/components/classifier/MultiAnswerClassifier.js
+++ b/src/components/classifier/MultiAnswerClassifier.js
@@ -1,0 +1,331 @@
+import React, { Component } from 'react';
+import {
+    ScrollView,
+    View
+} from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import PropTypes from 'prop-types'
+import R from 'ramda';
+
+import { getTaskFromWorkflow, getAnswersFromWorkflow } from '../../utils/workflow-utils'
+import { markdownContainsImage } from '../../utils/markdownUtils'
+import * as classifierActions from '../../actions/classifier'
+import ClassifierContainer from './ClassifierContainer'
+import ClassificationPanel from './ClassificationPanel'
+import NeedHelpButton from './NeedHelpButton'
+import Tutorial from './Tutorial';
+import OverlaySpinner from '../OverlaySpinner'
+import Question from './Question'
+import Separator from '../common/Separator'
+import ClassifierButton from './ClassifierButton'
+import FullScreenImage from '../FullScreenImage'
+import TapableSubject from './TapableSubject';
+
+class MultiAnswerClassifier extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            isQuestionVisible: true,
+            showFullSize: false,
+            fullScreenImageSource: { uri: '' },
+            fullScreenQuestion: '',
+            imageDimensions: { width: 0, height: 0 },
+            answerSelected: -1
+        }
+    }
+
+    setQuestionVisibility() {
+        return (isVisible) => {
+            this.setState({isQuestionVisible: isVisible})
+        }
+    }
+    
+    finishTutorial() {
+      if (this.props.needsTutorial) {
+        this.props.classifierActions.setTutorialCompleted(this.props.workflow.id, this.props.project.id)
+      } else {
+        this.setQuestionVisibility()(true)
+      }
+    }
+
+    onOptionSelected(index) {
+      return () => {
+        this.setState({
+          answerSelected: index
+        })
+
+        setTimeout(() => this.scrollView.scrollToEnd(), 300)
+      }
+    }
+
+    submitClassification() {
+      return () => {
+        const {
+          classifierActions,
+          workflow,
+          subject
+        } = this.props
+        const { id, first_task } = workflow
+        const { 
+          answerSelected,
+          imageDimensions
+        } = this.state
+
+        this.scrollView.scrollTo({x: 0, y: 0})
+        classifierActions.addAnnotationToTask(id, first_task, answerSelected, false)
+        classifierActions.saveClassification(workflow, subject, imageDimensions)
+
+        this.setState({
+          answerSelected: -1
+        })
+      }
+    }
+
+    render() {
+      const {
+        isFetching,
+        isSuccess,
+        needsTutorial,
+        tutorial,
+        project,
+        workflow,
+        subject,
+        subjectsSeenThisSession,
+        task,
+        inBetaMode,
+        guide,
+        answers
+      } = this.props
+
+      const {
+        answerSelected,
+        imageDimensions,
+        isQuestionVisible,
+        fullScreenImageSource,
+        fullScreenQuestion,
+        showFullSize
+      } = this.state
+
+      if (isFetching || !isSuccess) {
+          return <OverlaySpinner overrideVisibility={isFetching} />
+      }
+
+      const renderTutorial = () =>
+          <View style={styles.tutorialContainer}>
+              <Tutorial
+                  projectName={project.display_name}
+                  isInitialTutorial={needsTutorial}
+                  tutorial={tutorial}
+                  finishTutorial={() => this.finishTutorial()}
+              />
+          </View>
+
+      const question =
+          <View>
+            <Question
+              question={task.question}
+              workflowID={workflow.id}
+              onPressImage={(src, question) => {
+                this.setState({ 
+                  showFullSize: true,
+                  fullScreenImageSource: ({uri: src}),
+                  fullScreenQuestion: question
+                })}
+              }
+            />
+            {
+              markdownContainsImage(task.question) ? 
+                <Separator style={styles.questionSeparator} />
+              :
+                null
+            }
+          </View>   
+
+      const seenThisSession = R.indexOf(subject.id, subjectsSeenThisSession) >= 0
+      const classificationPanel =
+          <View style={styles.classificationPanel}>
+            <ClassificationPanel
+              hasTutorial = { !R.isEmpty(tutorial) }
+              isQuestionVisible = {isQuestionVisible }
+              setQuestionVisibility = { this.setQuestionVisibility() }
+            >
+              {
+                isQuestionVisible &&
+                  <View>
+                    { question }
+                  </View>
+              }
+            </ClassificationPanel>
+            {
+              isQuestionVisible ?
+                <ScrollView 
+                  style={styles.scrollView}
+                  ref={ref => this.scrollView = ref}
+                >
+                  <View style={styles.backgroundView} />
+                  <View style={styles.classifierContainer}>
+                    <View onLayout={({nativeEvent}) => this.setState({imageDimensions: {width: nativeEvent.layout.width, height: nativeEvent.layout.height}})}>
+                      <TapableSubject
+                        height={300}
+                        width={imageDimensions.width}
+                        subject={subject}
+                        alreadySeen={seenThisSession}
+                        onPress={(imageSource) => this.setState({
+                          showFullSize: true,
+                          fullScreenImageSource: {uri: imageSource}})}
+                      />
+                    </View>
+                    {
+                      answers.map((answer, index) =>
+                        <View key={index} style={styles.buttonContainer}>
+                          <ClassifierButton
+                            selected={index === answerSelected}
+                            blurred={answerSelected !== -1 && index !== answerSelected}
+                            type="answer"
+                            text={answer.label}
+                            onPress={this.onOptionSelected(index)}
+                          />
+                        </View>
+                      )
+                    }
+                  </View>
+                  <View style={styles.buttonContainer}>
+                    <ClassifierButton
+                      disabled={answerSelected === -1}
+                      type="answer"
+                      text="Submit"
+                      onPress={this.submitClassification()}
+                    />
+                  </View>
+                  {
+                    (task.help || R.length(guide.items) > 0) && 
+                      <Separator style={styles.separator}/>
+                  }
+                  { 
+                    task.help && 
+                      <NeedHelpButton 
+                        onPress={() => this.classifierContainer.displayHelpModal()}
+                      />
+                  }
+                  {
+                    R.length(guide.items) > 0 &&
+                      <ClassifierButton
+                        onPress={() => this.classifierContainer.displayFieldGuide()}
+                        style={styles.guideButton}
+                        text="Field Guide"
+                        type="guide"
+                      />
+                  }
+                </ScrollView>
+              :
+                renderTutorial()
+            }
+            <FullScreenImage
+              source={fullScreenImageSource}
+              isVisible={showFullSize}
+              handlePress={() => this.setState({ fullScreenQuestion: '', showFullSize: false })}
+              question={fullScreenQuestion}
+            />
+          </View>
+
+        return (
+                <View style={styles.container}>
+                    <ClassifierContainer
+                        inBetaMode={inBetaMode}
+                        project={project}
+                        help={task.help}
+                        guide={guide}
+                        ref={ref => this.classifierContainer = ref}
+                    >
+                        { needsTutorial ? renderTutorial() : classificationPanel }
+                    </ClassifierContainer>
+                </View>
+        );
+    }
+}
+
+MultiAnswerClassifier.propTypes = {
+    project: PropTypes.object,
+    workflow: PropTypes.object,
+    display_name: PropTypes.string,
+    inPreviewMode: PropTypes.bool,
+    inBetaMode: PropTypes.bool,
+    guide: PropTypes.object,
+    isFetching: PropTypes.bool,
+    isSuccess: PropTypes.bool,
+    needsTutorial: PropTypes.bool,
+    tutorial: PropTypes.object,
+    subject: PropTypes.object,
+    subjectsSeenThisSession: PropTypes.array,
+    task: PropTypes.object,
+    answers: PropTypes.array,
+    classifierActions: PropTypes.any
+}
+
+const styles = EStyleSheet.create({
+    container: {
+        flex: 1
+    },
+    classificationPanel: {
+        flex: 1,
+        overflow: 'visible',
+        marginBottom: 15,
+	},
+	classifierContainer: {
+		paddingHorizontal: 15,
+		paddingVertical: 15,
+		backgroundColor: 'white'
+  },
+  tutorialContainer: {
+    flex: 1,
+    backgroundColor: 'white',
+    marginHorizontal: 25
+  },
+  scrollView: {
+    flex: 1,
+    marginHorizontal: 25
+  },
+  backgroundView: {
+    backgroundColor: 'white',
+    height: 200,
+    position: 'absolute',
+    top: -200,
+    left: 0,
+    right: 0,
+  },
+  buttonContainer: {
+    marginTop: 10
+  },
+  separator: {
+    marginTop: 25
+  },
+  guideButton: {
+    marginTop: 15
+  }
+})
+
+const mapStateToProps = (state, ownProps) => {
+    return {
+      task: getTaskFromWorkflow(ownProps.workflow),
+      answers: getAnswersFromWorkflow(ownProps.workflow),
+      isSuccess: state.classifier.isSuccess,
+      isFailure: state.classifier.isFailure,
+      isFetching: state.classifier.isFetching,
+      annotations: state.classifier.annotations[ownProps.workflow.id] || {},
+      guide: state.classifier.guide[ownProps.workflow.id] || {},
+      tutorial: state.classifier.tutorial[ownProps.workflow.id] || {},
+      needsTutorial: state.classifier.needsTutorial[ownProps.workflow.id] || false,
+      subject: state.classifier.subject || {},
+      subjectsSeenThisSession: state.classifier.seenThisSession[ownProps.workflow.id] || []
+   }
+  }
+  
+  const mapDispatchToProps = (dispatch) => ({
+    classifierActions: bindActionCreators(classifierActions, dispatch),
+  })
+
+export default connect(mapStateToProps, mapDispatchToProps)(MultiAnswerClassifier);

--- a/src/components/classifier/MultiAnswerClassifier.js
+++ b/src/components/classifier/MultiAnswerClassifier.js
@@ -54,12 +54,18 @@ class MultiAnswerClassifier extends Component {
 
     onOptionSelected(answersSelected, index) {
       return () => {
-        var addedAnswer = answersSelected.concat(index)
-        this.setState({
-            answersSelected: addedAnswer
-        })
+          var updatedSelection = []
+          if (answersSelected.includes(index)) {
+              updatedSelection = answersSelected.filter(function(element) { return element !== index })
+          } else {
+              updatedSelection = answersSelected.concat(index)
+          }
 
-        setTimeout(() => this.scrollView.scrollToEnd(), 300)
+          this.setState({
+              answersSelected: updatedSelection
+          })
+
+          setTimeout(() => this.scrollView.scrollToEnd(), 300)
       }
     }
 

--- a/src/components/classifier/MultiAnswerClassifier.js
+++ b/src/components/classifier/MultiAnswerClassifier.js
@@ -213,7 +213,7 @@ class MultiAnswerClassifier extends Component {
                       <Separator style={styles.separator}/>
                   }
                   {
-                    task.help &&
+                    task.help !== null &&
                       <NeedHelpButton
                         onPress={() => this.classifierContainer.displayHelpModal()}
                       />

--- a/src/components/classifier/QuestionClassifier.js
+++ b/src/components/classifier/QuestionClassifier.js
@@ -206,7 +206,7 @@ class QuestionClassifier extends Component {
                       <Separator style={styles.separator}/>
                   }
                   { 
-                    task.help && 
+                        task.help !== null &&
                       <NeedHelpButton 
                         onPress={() => this.classifierContainer.displayHelpModal()}
                       />

--- a/src/constants/PageKeys.js
+++ b/src/constants/PageKeys.js
@@ -10,6 +10,7 @@ const PageKeys = {
     ZooWebView: 'ZooWebView',
     SwipeClassifier: 'SwipeClassifier',
     QuestionClassifier: 'QuestionClassifier',
+    MultiAnswerClassifier: 'MultiAnswerClassifier',
     WebView: 'WebView',
     DrawingClassifier: 'DrawingClassifier'
 }

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -32,6 +32,7 @@ import storage from 'redux-persist/lib/storage'
 import { PersistGate } from 'redux-persist/integration/react'
 import DrawingClassifier from '../components/Markings/DrawingClassifier'
 import QuestionClassifier from '../components/classifier/QuestionClassifier'
+import MultiAnswerClassifier from '../components/classifier/MultiAnswerClassifier'
 import SafeAreaContainer from './SafeAreaContainer'
 import { setPageShowing } from '../actions/navBar'
 import NavBar from '../components/NavBar';
@@ -102,6 +103,7 @@ export default class App extends Component {
                     <Scene key={PageKeys.WebView} component={WebViewScreen} />
                     <Scene key={PageKeys.DrawingClassifier} drawerLockMode={'locked-closed'} panHandlers={null} component={DrawingClassifier} />
                     <Scene key={PageKeys.QuestionClassifier} component={QuestionClassifier} />
+                    <Scene key={PageKeys.MultiAnswerClassifier} component={MultiAnswerClassifier} />
                   </Scene>
               </Drawer>
             </Router>

--- a/src/navigators/classifierNavigator.js
+++ b/src/navigators/classifierNavigator.js
@@ -18,8 +18,11 @@ const navigateToClassifier = R.curry((dispatch, inPreviewMode, inBetaMode, proje
         case 'drawing':
             navigateToDrawingClassifier(inPreviewMode, inBetaMode, project, workflow, dispatch);
             break;
-        case 'question':
+        case 'single':
             navigateToQuestionClassifier(inPreviewMode, inBetaMode, project, workflow, dispatch);
+            break;
+        case 'multiple':
+            navigateToMultiAnswerClassifier(inPreviewMode, inBetaMode, project, workflow, dispatch);
             break;
         case 'swipe':
             navigateToSwipeClassifier(inPreviewMode, inBetaMode, project, workflow, dispatch);
@@ -31,10 +34,12 @@ function getPageKeyForWorkflowType(workflowType) {
     switch (workflowType) {
         case 'drawing':
             return PageKeys.DrawingClassifier;
-        case 'question':
+        case 'single':
             return PageKeys.QuestionClassifier;
         case 'swipe': 
             return PageKeys.SwipeClassifier;
+        case 'multiple':
+            return PageKeys.MultiAnswerClassifier;
     }
 }
 
@@ -54,6 +59,18 @@ function navigateToQuestionClassifier(inPreviewMode, inBetaMode, project, workfl
     dispatch(classifierActions.clearClassifierData())
     dispatch(classifierActions.startNewClassification(workflow, project))
     Actions.QuestionClassifier({ 
+        project,
+        workflow,
+        display_name: project.display_name,
+        inPreviewMode,
+        inBetaMode
+    })
+}
+
+function navigateToMultiAnswerClassifier(inPreviewMode, inBetaMode, project, workflow, dispatch) {
+    dispatch(classifierActions.clearClassifierData())
+    dispatch(classifierActions.startNewClassification(workflow, project))
+    Actions.MultiAnswerClassifier({
         project,
         workflow,
         display_name: project.display_name,

--- a/src/utils/workflow-utils.js
+++ b/src/utils/workflow-utils.js
@@ -29,7 +29,6 @@ const isValidQuestionWorkflow = (workflow) => {
     return false
   }
   const firstTask = workflow.tasks[workflow.first_task]
-  const hasTwoAnswers = firstTask.answers.length === 2
 
   const hasSingleTask = workflowHasSingleTask(workflow)
 
@@ -42,7 +41,7 @@ const isValidQuestionWorkflow = (workflow) => {
   const doesNotUseFeedback = firstTask.feedback ? !firstTask.feedback.enabled : true;
 
   if (hasSingleTask && questionNotTooLong && notTooManyShortcuts && isNotFlipbook && doesNotUseFeedback) {
-    workflow.type = hasTwoAnswers ? 'swipe' : 'question'
+    workflow.type = firstTask.type
     return true
   }
 

--- a/src/utils/workflow-utils.js
+++ b/src/utils/workflow-utils.js
@@ -42,6 +42,13 @@ const isValidQuestionWorkflow = (workflow) => {
 
   if (hasSingleTask && questionNotTooLong && notTooManyShortcuts && isNotFlipbook && doesNotUseFeedback) {
     workflow.type = firstTask.type
+
+    const hasTwoAnswers = firstTask.answers.length === 2
+    if (hasTwoAnswers && workflow.type === 'single') {
+        // This is a special, mobile-only flow where users swipe left and right for questions where they choose on of two answers
+        workflow.type = 'swipe'
+    }
+
     return true
   }
 


### PR DESCRIPTION
+ Switch task type assignment to key off the API value rather than the number of answers in the task.
+ BEFORE MERGING: Chelsea will remove TODOs in projects.js. These TODOs allow work on this feature to continue while the panoptes frontend still classifies multi answer workflows as not mobile_friendly.

This PR allows us to include projects in the mobile app that ask users to select multiple answers from a list of answers. There are two test projects in Preview: one that allows you to check multi answer, and one to allow you to check that single answer still works. @mcbouslog and I verified together that the call to the backend works correctly - yay!

I can make the "BEFORE MERGING" changes described above and release this whenever, but multi-answer projects will only start to show up on the app after some changes are made on the front end as described in the following issue: https://github.com/zooniverse/Panoptes-Front-End/issues/5374

# Review Checklist

- [x] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected? <--with adjustments described in README
- [x] Are tests passing?

