### PR TITLE
Blacklist Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Setting up to work on a react-native app is a little tricky, and setting up to w
 1. Follow the instructions for Android and iOS setup in [this guide](https://facebook.github.io/react-native/docs/getting-started.html).
 1. Clone down this repo and navigate to its directory (called `mobile`).
 1. Run `npm install` (later, if you need to reinstall dependencies for some reason, you can run `rm -rf node_modules/ && npm install`)
-1. Open the `mobile` directory in your IDE of choice. navigate to `node_modules/react-native-deck-swiper/node_modules` and delete the `react-native` directory you find in there.
-    - When we run the app, the presence of this version of react-native in addition to the dependency for the app itself creates a conflict. You'll know that this is what you're running into if you get an error about @hasteImpl returning two modules of the same name.
-    - This happens because zooniverse has its own fork of the `react-native-deck-swiper` module. Although we have removed `react-native` from the `package.json`, something else in it must be requiring this dependency. It's on the list of issues to address, to have our dependency fork not ship with this copy of `react-native`.
 1. Run `npm start`.
 
 ### Setting up to run on iOS

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,8 +4,14 @@
  *
  * @format
  */
+const blacklist = require('metro-config/src/defaults/blacklist')
 
 module.exports = {
+    resolver: {
+      blacklistRE: blacklist([
+          /node_modules\/.*\/node_modules\/react-native\/.*/,
+      ])
+    },
     transformer: {
         getTransformOptions: async () => ({
             transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8964,8 +8964,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8983,13 +8982,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9002,18 +8999,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9116,8 +9110,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9127,7 +9120,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9140,20 +9132,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9170,7 +9159,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9243,8 +9231,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9254,7 +9241,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9330,8 +9316,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9361,7 +9346,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9379,7 +9363,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9418,13 +9401,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -16403,7 +16384,7 @@
       "integrity": "sha1-TUYvjO0mOTxSMEZ0IMYaUMxqgJU=",
       "requires": {
         "lodash": "^4.15.0",
-        "simple-markdown": "git://github.com/CharlesMangwa/simple-markdown.git"
+        "simple-markdown": "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1"
       }
     },
     "react-native-simple-store": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-splash-screen": "^3.0.6",
     "react-native-svg": "9.4.0",
     "react-native-swiper": "^1.5.13",
-    "react-native-vector-icons": "6.1.0",
+    "react-native-vector-icons": "^6.1.0",
     "react-native-webview-bridge": "^0.33.0",
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",


### PR DESCRIPTION
Describe your changes.
This PR takes care of a few issues. It removes the need to manually delete the `react-native` package from the `react-native-deck-swiper` node_modules and updates the Readme accordingly. It also fixes the issues we were having with `npm run android` running into `react-native-vector-icons` issues.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

