### PR TITLE
Double Project Issue

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,8 +107,8 @@ android {
         applicationId "com.zooniversemobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 41
-        versionName "2.6.1"
+        versionCode 42
+        versionName "2.6.2"
         multiDexEnabled true
     }
     signingConfigs {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -16,6 +16,7 @@ const productionParams = {
 const betaParams = {
     mobile_friendly: true,
     beta_approved: true,
+    launch_approved: false,
     include: 'avatar',
     sort: 'display_name',
     live: true,


### PR DESCRIPTION
Turns out when we approve a project for launch, it stays beta approved, too. So projects that did both beta and launch were showing up twice in the app. We have tweaked the filters to prevent that.

Reviewers:

1. Thank you for all your help!
2. To ensure that this works, please verify that on your device (pointed at production) the following projects show up exactly once (not twice, not zero times):

- Bash the Bug: fighting antibiotic resistance 
- Camera CATalogue: analyzing wildlife photos to help Panthera protect big cats
- Euclid Challenge the Machines: identifying simulated gravitational lenses 
- Floating Forest: mapping change across the world’s giant kelp forests 
- Galaxy Zoo: separating smooth galaxies from those with features 
- Grouse Grooves: helping to conserve the greater sage-grouse
- Radio Meteor Zoo: marking meteors
- Snapshot Karoo: tracking animal migrations across Karoo National Park in South Africa.
- Unearthing Michigan Ecological Data: unearthing buried ecological datasets  

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

