### PR TITLE
Allow Flipbook

### DIFF
--- a/src/utils/workflow-utils.js
+++ b/src/utils/workflow-utils.js
@@ -8,7 +8,7 @@ export const getTaskFromWorkflow = (workflow) => {
     const key = workflow.first_task
     return workflow.tasks[key]
   }
-  
+
 export const getAnswersFromWorkflow = (workflow) => {
     const task = getTaskFromWorkflow(workflow)
     return task.answers
@@ -37,10 +37,9 @@ const isValidQuestionWorkflow = (workflow) => {
 
   const questionNotTooLong = firstTask.question.length < 200
   const notTooManyShortcuts = shortcut ? shortcut.answers.length <= 2 : true
-  const isNotFlipbook = config ? config.multi_image_mode !== 'flipbook' : true
   const doesNotUseFeedback = firstTask.feedback ? !firstTask.feedback.enabled : true;
 
-  if (hasSingleTask && questionNotTooLong && notTooManyShortcuts && isNotFlipbook && doesNotUseFeedback) {
+  if (hasSingleTask && questionNotTooLong && notTooManyShortcuts && doesNotUseFeedback) {
     workflow.type = firstTask.type
 
     const hasTwoAnswers = firstTask.answers.length === 2
@@ -62,9 +61,9 @@ const isValidDrawingWorkflow = (workflow) => {
 
   const firstTask = workflow.tasks[workflow.first_task]
   if (firstTask === undefined) {
-    return false 
+    return false
   }
-  
+
   if (firstTask.type !== 'drawing') {
     return false
   }

--- a/src/utils/workflow-utils.js
+++ b/src/utils/workflow-utils.js
@@ -33,7 +33,6 @@ const isValidQuestionWorkflow = (workflow) => {
   const hasSingleTask = workflowHasSingleTask(workflow)
 
   const shortcut = workflow.tasks[firstTask.unlinkedTask]
-  const config = workflow.configuration
 
   const questionNotTooLong = firstTask.question.length < 200
   const notTooManyShortcuts = shortcut ? shortcut.answers.length <= 2 : true


### PR DESCRIPTION
Fixes #278  .

Invision Mock-ups: 

Describe your changes.
This PR allows a workflow with a flipbook to be enabled in the app. Read more on the issue above. With the introduction of multi-image subjects, it shouldn't be an issue having a workflow with a flipbook in the app.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

