### PR TITLE
Only Mark Museum Mode if User Has Role

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16038,7 +16038,6 @@
             "prop-types": "^15.5.8",
             "react-clone-referenced-element": "^1.0.1",
             "react-devtools-core": "^3.4.2",
-            "react-timer-mixin": "^0.13.2",
             "regenerator-runtime": "^0.11.0",
             "rimraf": "^2.5.4",
             "semver": "^5.0.3",
@@ -16257,8 +16256,13 @@
       "resolved": "https://registry.npmjs.org/react-native-simple-markdown/-/react-native-simple-markdown-1.1.0.tgz",
       "integrity": "sha1-TUYvjO0mOTxSMEZ0IMYaUMxqgJU=",
       "requires": {
-        "lodash": "^4.15.0",
-        "simple-markdown": "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1"
+        "lodash": "^4.15.0"
+      },
+      "dependencies": {
+        "simple-markdown": {
+          "version": "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1",
+          "from": "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1"
+        }
       }
     },
     "react-native-simple-store": {
@@ -17492,10 +17496,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-markdown": {
-      "version": "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1",
-      "from": "git://github.com/CharlesMangwa/simple-markdown.git"
     },
     "simple-plist": {
       "version": "1.0.0",

--- a/src/actions/__tests__/projects-test.js
+++ b/src/actions/__tests__/projects-test.js
@@ -1,0 +1,30 @@
+import { tagMuseumRoleForProjects } from '../projects'
+import apiClient from 'panoptes-client/lib/api-client'
+
+describe('function > tagMuseumRoleForProjects', function() {
+  test('it tags a project in_museum_mode if user has museum role', async () => {
+    jest
+      .spyOn(apiClient, 'type')
+      .mockImplementation(() => {
+        return {
+          get: () => Promise.resolve([{ id: '1' }])
+        }
+      })
+    let projects = [{ id: '1' }, { id: '2' }]
+    await tagMuseumRoleForProjects(projects)
+    expect(projects[0].in_museum_mode).toBe(true)
+  })
+
+  test('it won\'t tag a project in_museum_mode without user role', async () => {
+    jest
+      .spyOn(apiClient, 'type')
+      .mockImplementation(() => {
+        return {
+          get: () => Promise.resolve([])
+        }
+      })
+    let projects = [{ id: '1' }, { id: '2' }]
+    await tagMuseumRoleForProjects(projects)
+    expect(projects[0].in_museum_mode).toBe(false)
+  })
+})

--- a/src/actions/__tests__/projects-test.js
+++ b/src/actions/__tests__/projects-test.js
@@ -20,11 +20,11 @@ describe('function > tagMuseumRoleForProjects', function() {
       .spyOn(apiClient, 'type')
       .mockImplementation(() => {
         return {
-          get: () => Promise.resolve([])
+          get: () => Promise.resolve([{ id: '1' }])
         }
       })
     let projects = [{ id: '1' }, { id: '2' }]
     await tagMuseumRoleForProjects(projects)
-    expect(projects[0].in_museum_mode).toBe(false)
+    expect(projects[1].in_museum_mode).toBe(false)
   })
 })

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -83,7 +83,7 @@ export function fetchProjects() {
                     let projectDetailCalls = []
                     projectDetailCalls.push(getWorkflowsForProjects(allProjects))
                     const avatarCall = getAvatarsForProjects(allProjects)
-                    const museumModeCall = tagMuseumRoleForProjects(allProjects, userProfile)
+                    const museumModeCall = tagMuseumRoleForProjects(allProjects)
 
                     projectDetailCalls = projectDetailCalls.concat(avatarCall)
                     if (userIsLoggedIn) {
@@ -123,7 +123,7 @@ const getAvatarsForProjects = projects => {
     })
 }
 
-const tagMuseumRoleForProjects = (projects) => {
+export const tagMuseumRoleForProjects = projects => {
     return apiClient.type('projects')
       .get({ current_user_roles: 'museum' })
       .then((museumProjects) => {

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -83,10 +83,12 @@ export function fetchProjects() {
                     let projectDetailCalls = []
                     projectDetailCalls.push(getWorkflowsForProjects(allProjects))
                     const avatarCall = getAvatarsForProjects(allProjects)
-                    const museumModeCall = getMuseumRoleForProjects(allProjects)
+                    const museumModeCall = tagMuseumRoleForProjects(allProjects, userProfile)
 
                     projectDetailCalls = projectDetailCalls.concat(avatarCall)
-                    projectDetailCalls = projectDetailCalls.concat(museumModeCall)
+                    if (userIsLoggedIn) {
+                      projectDetailCalls = projectDetailCalls.concat(museumModeCall)
+                    }
                     // Then load the avatars and workflows
                     Promise.all(projectDetailCalls)
                         .then(() => {
@@ -121,16 +123,15 @@ const getAvatarsForProjects = projects => {
     })
 }
 
-const getMuseumRoleForProjects = projects => {
-    return projects.map(project => {
-        return apiClient.type('project_roles')
-            .get({id: project.links.project_roles})
-            .then((roles) => {
-                roles.forEach(role => {
-                    project.in_museum_mode = project.in_museum_mode || role.roles.includes('museum')
-                })
-            })
-    })
+const tagMuseumRoleForProjects = (projects) => {
+    return apiClient.type('projects')
+      .get({ current_user_roles: 'museum' })
+      .then((museumProjects) => {
+        const museumProjIds = museumProjects.map(project => project.id)
+        projects.forEach(project => {
+          project.in_museum_mode = project.in_museum_mode || museumProjIds.includes(project.id)
+        })
+      })
 }
 
 const getWorkflowsForProjects = projects => {


### PR DESCRIPTION
Fixes #303 

Invision Mock-ups: 

Describe your changes.
- Optimize the way we set museum mode. Instead of a call for all `project_roles` on every project in the mobile app, we make a single call for all projects where the current user has the `museum` role, but only if logged in.
- For those projects with the museum role, the `in_museum_mode` flag is triggered if they are in the app.

When reviewing, you can test this out with the Project With All Mobile Workflow Types, which I've promoted to Beta Review and should be available to both logged in and anonymous users.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

