### PR TITLE
Fix Museum Mode Fast Tap Issue (appears to be specific to drawing workflow)

### DIFF
--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -218,7 +218,7 @@ class DrawingClassifier extends Component {
         const submitButton =
             <SubmitButton
                 inMuseumMode={this.props.project.in_museum_mode}
-                disabled={R.keys(this.props.shapes).length < tool.min}
+                disabled={R.keys(this.props.shapes).length < tool.min || !this.state.imageIsLoaded}
                 onPress={this.submitClassification}
                 style={[styles.submitButton, this.state.orientation === 'portrait' ? [] : styles.wideSubmit]}
                 text="Submit"


### PR DESCRIPTION
Children can mash the submit button all they want, but it disables after the first press until a new image loads

+ I also checked whether other workflows have this problem. I was not able to reproduce the issue in the other workflows.

Fixes https://github.com/zooniverse/mobile/issues/310.

Invision Mock-ups: 

Describe your changes.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

