### PR TITLE
Edit  Social Science Key to show Icon

### DIFF
--- a/src/constants/globals.js
+++ b/src/constants/globals.js
@@ -12,7 +12,7 @@ export const GLOBALS = {
     'medicine': 61744,
     'nature': 61739,
     'physics': 61740,
-    'social-science': 61745,
+    'social science': 61745,
     'zooniverse-logo': 61729
   },
   //description: 'Help review projects to see if they are ready for launch',


### PR DESCRIPTION
Fixes #292 

Invision Mock-ups: 

Describe your changes.
The social sciences icon was not looking for the correct key value. The `GLYPHMAP` was using `'social-science'` instead of `'social science'`
# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

