### PR TITLE
Don't Disable Continue without Signing In Button

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -82,7 +82,6 @@ export class SignIn extends React.Component {
 
   render() {
     const signInDisabled = ( (this.state.login === '') || (this.state.password ===  '') ? true : false )
-    const continueTinted = !signInDisabled
 
     const errorMessage =
       <StyledText
@@ -125,7 +124,6 @@ export class SignIn extends React.Component {
 
             <Button
               handlePress={this.continueAsGuest}
-              buttonStyle={ continueTinted ? 'disabledButton' : null }
               text={'Continue without signing in'} />
 
             <Button


### PR DESCRIPTION
Moving towards #148 

Describe your changes.
This is the first step in closing the issue above. It is going to take a bit more work to take care of the second item in this issue (bringing back the < button on the sign in screen). Adding `showBack: true` [here](https://github.com/zooniverse/mobile/blob/master/src/components/SignIn.js#L77) initially takes care of it, but there is a use case where a logged-in user signs out, views the sign in screen, hits the back button, and would see a screen without disciplines.

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

