### PR TITLE
Fix hidden remove buttons

### DIFF
--- a/src/components/Markings/components/EditableRect.js
+++ b/src/components/Markings/components/EditableRect.js
@@ -21,15 +21,15 @@ class EditableRect extends Component {
     /**
      * Because Svgs don't plug in to react-native's animation engine,
      * we have to update their props natively.
-     * 
+     *
      * This function handles updating the props of the svgs of this component by
      * taking an object of deltas
-     * 
+     *
      * @param {An object that contains deltas to be applied to the shape} deltas
      */
-    update({dx, dy, dw, dh}) {        
+    update({ dx, dy, dw, dh }) {
         const newWidth = this.props.width + dw < 0.1 ? this.props.width + dw + 1 : this.props.width + dw
-        const newHeight = this.props.height + dh < 0.1 ? this.props.height + dh + 1: this.props.height + dh
+        const newHeight = this.props.height + dh < 0.1 ? this.props.height + dh + 1 : this.props.height + dh
         const newX = this.props.x + dx < 0.1 ? this.props.x + dx + 1 : this.props.x + dx
         const newY = this.props.y + dy < 0.1 ? this.props.y + dy + 1 : this.props.y + dy
 
@@ -49,7 +49,7 @@ class EditableRect extends Component {
             && this.upperRightCircle
             && this.bottomRightCircle
             && this.bottomLeftCircle
-            ) {
+        ) {
             this.upperLeftCircle.setNativeProps({
                 cx: `${newX}`,
                 cy: `${newY}`,
@@ -71,6 +71,37 @@ class EditableRect extends Component {
         return newDimensions
     }
 
+    renderCloseButton() {
+        const buttonRadius = 20;
+        const {
+            width, height, nativeWidth, x, y, displayToNativeRatioX, onCloseLayout, onDelete, color
+        } = this.props
+
+
+        const normalizedX = width > 0 ? x : x + width
+        const shapeRightX = normalizedX + Math.abs(width)
+        const newX = shapeRightX > nativeWidth - buttonRadius
+            ? Math.max(normalizedX - buttonRadius, 0)
+            : shapeRightX
+
+
+        const normalizedY = height > 0 ? y : y + height
+        const newY = newX === 0 || normalizedY < buttonRadius
+            ? normalizedY
+            : normalizedY - buttonRadius
+
+        return (
+            <G x={newX} y={newY}>
+                <CloseButtonSVG
+                    displayToNativeRatio={displayToNativeRatioX}
+                    onLayout={onCloseLayout}
+                    color={color}
+                    onPress={onDelete}
+                />
+            </G>
+        )
+    }
+
     render() {
         return (
             <G>
@@ -86,7 +117,7 @@ class EditableRect extends Component {
                     fill={this.props.blurred ? Color(this.props.color).alpha(0.3).toString() : 'transparent'}
                 />
                 {
-                    this.props.showCorners ? 
+                    this.props.showCorners ?
                         <G>
                             <Circle
                                 ref={ref => this.upperLeftCircle = ref}
@@ -122,22 +153,9 @@ class EditableRect extends Component {
                             />
                         </G> : null
                 }
+
                 {
-                    
-                    this.props.isDeletable ?
-                        <G
-                            x={this.props.width > 0 ? this.props.width + this.props.x : this.props.x}
-                            y={(this.props.height > 0 ? this.props.y : this.props.y - Math.abs(this.props.height)) - (15 * this.props.displayToNativeRatioY)}
-                        >
-                            <CloseButtonSVG
-                                displayToNativeRatio={this.props.displayToNativeRatioX}
-                                onLayout={this.props.onCloseLayout}
-                                color={this.props.color}
-                                onPress={this.props.onDelete}
-                            />
-                        </G>
-                    :
-                        null
+                    this.props.isDeletable && this.renderCloseButton(this.props)
                 }
             </G>
         )
@@ -150,6 +168,7 @@ EditableRect.propTypes = {
     displayToNativeRatioY: PropTypes.number,
     x: PropTypes.number,
     y: PropTypes.number,
+    nativeWidth: PropTypes.number.isRequired,
     width: PropTypes.number,
     height: PropTypes.number,
     color: PropTypes.string,

--- a/src/components/Markings/components/EditableRect.js
+++ b/src/components/Markings/components/EditableRect.js
@@ -72,11 +72,10 @@ class EditableRect extends Component {
     }
 
     renderCloseButton() {
-        const buttonRadius = 20;
+        const buttonRadius = 24;
         const {
             width, height, nativeWidth, x, y, displayToNativeRatioX, onCloseLayout, onDelete, color
         } = this.props
-
 
         const normalizedX = width > 0 ? x : x + width
         const shapeRightX = normalizedX + Math.abs(width)
@@ -88,7 +87,7 @@ class EditableRect extends Component {
         const normalizedY = height > 0 ? y : y + height
         const newY = newX === 0 || normalizedY < buttonRadius
             ? normalizedY
-            : normalizedY - buttonRadius
+            : normalizedY - buttonRadius / 2
 
         return (
             <G x={newX} y={newY}>

--- a/src/components/Markings/components/EditableRect.js
+++ b/src/components/Markings/components/EditableRect.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 import Color from 'color';
 
 import CloseButtonSVG from './CloseButtonSVG'
+import { calculateDeleteButtonPosition } from '../../../utils/shapeUtils'
 
 export const RectCorners = {
     upperLeft: 'upperLeft',
@@ -72,25 +73,14 @@ class EditableRect extends Component {
     }
 
     renderCloseButton() {
-        const buttonRadius = 24;
         const {
             width, height, nativeWidth, x, y, displayToNativeRatioX, onCloseLayout, onDelete, color
         } = this.props
 
-        const absoluteX = width > 0 ? x : x + width
-        const shapeRightX = absoluteX + Math.abs(width)
-        const newX = shapeRightX > nativeWidth - buttonRadius
-            ? Math.max(absoluteX - buttonRadius, 0)
-            : shapeRightX
-
-
-        const absoluteY = height > 0 ? y : y + height
-        const newY = newX === 0 || absoluteY < buttonRadius
-            ? absoluteY
-            : absoluteY - buttonRadius / 2
+        const closePosition = calculateDeleteButtonPosition(x, y, width, height, nativeWidth, displayToNativeRatioX)
 
         return (
-            <G x={newX} y={newY}>
+            <G x={closePosition.x} y={closePosition.y}>
                 <CloseButtonSVG
                     displayToNativeRatio={displayToNativeRatioX}
                     onLayout={onCloseLayout}
@@ -126,6 +116,7 @@ class EditableRect extends Component {
                                 fill={this.props.color}
                                 r={16 * this.props.displayToNativeRatioX}
                             />
+
                             <Circle
                                 ref={ref => this.upperRightCircle = ref}
                                 onLayout={(event) => this.props.onCornerLayout(event, RectCorners.upperRight)}

--- a/src/components/Markings/components/EditableRect.js
+++ b/src/components/Markings/components/EditableRect.js
@@ -77,17 +77,17 @@ class EditableRect extends Component {
             width, height, nativeWidth, x, y, displayToNativeRatioX, onCloseLayout, onDelete, color
         } = this.props
 
-        const normalizedX = width > 0 ? x : x + width
-        const shapeRightX = normalizedX + Math.abs(width)
+        const absoluteX = width > 0 ? x : x + width
+        const shapeRightX = absoluteX + Math.abs(width)
         const newX = shapeRightX > nativeWidth - buttonRadius
-            ? Math.max(normalizedX - buttonRadius, 0)
+            ? Math.max(absoluteX - buttonRadius, 0)
             : shapeRightX
 
 
-        const normalizedY = height > 0 ? y : y + height
-        const newY = newX === 0 || normalizedY < buttonRadius
-            ? normalizedY
-            : normalizedY - buttonRadius / 2
+        const absoluteY = height > 0 ? y : y + height
+        const newY = newX === 0 || absoluteY < buttonRadius
+            ? absoluteY
+            : absoluteY - buttonRadius / 2
 
         return (
             <G x={newX} y={newY}>

--- a/src/components/Markings/components/MarkableImage.js
+++ b/src/components/Markings/components/MarkableImage.js
@@ -19,7 +19,7 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-     drawingActions: bindActionCreators(drawingActions, dispatch)
+    drawingActions: bindActionCreators(drawingActions, dispatch)
 })
 
 class MarkableImage extends Component {
@@ -53,13 +53,13 @@ class MarkableImage extends Component {
         this.props.drawingActions.mutateShapeAtIndex(modifications, index)
     }
 
-    onImageLayout({nativeEvent}) {
+    onImageLayout({ nativeEvent }) {
         const { height: containerHeight, width: containerWidth } = nativeEvent.layout
         const { naturalHeight, naturalWidth } = this.props.subjectDimensions
-        const aspectRatio = Math.min(containerHeight/naturalHeight, containerWidth/naturalWidth)
+        const aspectRatio = Math.min(containerHeight / naturalHeight, containerWidth / naturalWidth)
         const clientHeight = naturalHeight * aspectRatio
         const clientWidth = naturalWidth * aspectRatio
-        
+
         if (this.props.onContainerLayout) {
             this.props.onContainerLayout({
                 height: clientHeight,
@@ -77,16 +77,17 @@ class MarkableImage extends Component {
     render() {
         const { naturalHeight, naturalWidth } = this.props.subjectDimensions
         const pathPrefix = Platform.OS === 'android' ? 'file://' : ''
+
         return (
             <View style={styles.svgContainer}>
-                <ImageBackground 
+                <ImageBackground
                     onLayout={this.onImageLayout}
                     style={styles.svgOverlayContainer}
-                    source={{uri: pathPrefix + this.props.source}}
+                    source={{ uri: pathPrefix + this.props.source }}
                     resizeMode="contain"
                 >
                     {
-                        this.state.isImageLoaded ? 
+                        this.state.isImageLoaded ?
                             <SvgOverlay
                                 canDraw={this.props.canDraw}
                                 nativeWidth={naturalWidth}
@@ -103,7 +104,7 @@ class MarkableImage extends Component {
                                 onShapeModified={this.onShapeModified}
                                 onShapeIsOutOfBoundsUpdates={this.props.onShapeIsOutOfBoundsUpdates}
                             />
-                        :
+                            :
                             null
                     }
                 </ImageBackground>

--- a/src/components/Markings/components/ShapeEditorSvg.js
+++ b/src/components/Markings/components/ShapeEditorSvg.js
@@ -3,7 +3,7 @@ import {
     PanResponder,
     View
 } from 'react-native'
-import { 
+import {
     Rect,
     Svg,
 } from 'react-native-svg'
@@ -20,15 +20,15 @@ import {
 
 /**
  * This class handles all user interactions with shapes.
- * 
- * Because of some oddities with Pan Responders and Svgs in modals, 
+ *
+ * Because of some oddities with Pan Responders and Svgs in modals,
  * we need to tackle this problem in a somewhat round-about way.
- * 
- * Essentially every time a shape gets rendered we save its location, 
- * its corner locations and its close Svg location. 
- * 
+ *
+ * Essentially every time a shape gets rendered we save its location,
+ * its corner locations and its close Svg location.
+ *
  * When the user interacts with the pan responder, we determine based on the saved
- * location data if/which shape the user is touching. 
+ * location data if/which shape the user is touching.
  */
 
 const INITIAL_PREVIEW_SHAPE_SIDE = 2
@@ -63,7 +63,7 @@ class ShapeEditorSvg extends Component {
                 perimeterOnly: false
             },
             isDrawing: false,
-            dragOrigin: { x: 0, y: 0},
+            dragOrigin: { x: 0, y: 0 },
             previewShapeDimensions: this.previewShapeInitialDimensions()
         }
 
@@ -101,7 +101,7 @@ class ShapeEditorSvg extends Component {
                     return analyzeCoordinateWithShape(locationX, locationY, shape, this.cornerLocations[key])
                 }, this.shapeLocations)
                 const allShapesTouched = R.pickBy((analysis) => analysis.withinSquare, analyzedLocations)
-                
+
                 // If a shape is being touched, update state with where it's being touched
                 if (R.keys(allShapesTouched).length > 0) {
                     const touchedShapeIndex = R.keys(allShapesTouched)[0]
@@ -112,7 +112,7 @@ class ShapeEditorSvg extends Component {
                     })
                 }
 
-                // If a shape isn't being touched, then we should begin drawing a new shape 
+                // If a shape isn't being touched, then we should begin drawing a new shape
                 else if (!this.props.maxShapesDrawn) {
                     const previewShapeDimensions = R.merge(this.state.previewShapeDimensions, {
                         x: (locationX - INITIAL_PREVIEW_SHAPE_SIDE) * this.props.displayToNativeRatioX,
@@ -134,24 +134,24 @@ class ShapeEditorSvg extends Component {
 
                 if (shapeIndex >= 0) {
                     const shape = this.props.shapes[shapeIndex]
-                    const deltas = calculateShapeChanges(touchState, dx, dy, 
-                                                         this.props.displayToNativeRatioX, this.props.displayToNativeRatioY,
-                                                         shape, this.props.width, this.props.height, dragLocation)
+                    const deltas = calculateShapeChanges(touchState, dx, dy,
+                        this.props.displayToNativeRatioX, this.props.displayToNativeRatioY,
+                        shape, this.props.width, this.props.height, dragLocation)
 
                     // Because Svgs don't have any way to animate, we have to update their props manually
                     const newDimensions = this.shapeRefs[shapeIndex].update(deltas);
-                    const shapeIsOutOfBounds = isShapeOutOfBounds(newDimensions, {width: this.props.width *this.props.displayToNativeRatioX, height: this.props.height * this.props.displayToNativeRatioY})
+                    const shapeIsOutOfBounds = isShapeOutOfBounds(newDimensions, { width: this.props.width * this.props.displayToNativeRatioX, height: this.props.height * this.props.displayToNativeRatioY })
                     const shapeIsOutOfBoundsAndBeingDragged = shapeIsOutOfBounds && touchState.perimeterOnly
                     this.props.onShapeIsOutOfBoundsUpdates(shapeIsOutOfBoundsAndBeingDragged)
                     this.setState({
                         shapeToRemoveIndex: shapeIsOutOfBoundsAndBeingDragged ? shapeIndex : -1
                     })
-                } 
-                
-                if (isDrawing) {
-                    const previewShapeStartDimensions = R.merge(this.state.previewShapeDimensions, {width: 0, height: 0})
+                }
 
-                    const deltas = calculateShapeChanges(drawingTouchState, dx + INITIAL_PREVIEW_SHAPE_SIDE, dy + INITIAL_PREVIEW_SHAPE_SIDE, 
+                if (isDrawing) {
+                    const previewShapeStartDimensions = R.merge(this.state.previewShapeDimensions, { width: 0, height: 0 })
+
+                    const deltas = calculateShapeChanges(drawingTouchState, dx + INITIAL_PREVIEW_SHAPE_SIDE, dy + INITIAL_PREVIEW_SHAPE_SIDE,
                         this.props.displayToNativeRatioX, this.props.displayToNativeRatioY,
                         previewShapeStartDimensions, this.props.width, this.props.height, dragLocation)
 
@@ -170,10 +170,10 @@ class ShapeEditorSvg extends Component {
                 const { shapeIndex, touchState, isDrawing, shapeToRemoveIndex } = this.state
 
                 // Remove a shape if the user has dragged it off screen
-                if (shapeToRemoveIndex >= 0 && touchState.perimeterOnly) { 
+                if (shapeToRemoveIndex >= 0 && touchState.perimeterOnly) {
                     this.props.onShapeDeleted(shapeToRemoveIndex)
                 }
-                // If the user is editing a shape, update the shape changes 
+                // If the user is editing a shape, update the shape changes
                 else if (shapeIndex >= 0) {
                     const { dx, dy } = gestureState;
                     const dragLocation = {
@@ -182,7 +182,7 @@ class ShapeEditorSvg extends Component {
                     }
 
                     const shape = this.props.shapes[shapeIndex]
-                    const deltas = calculateShapeChanges(touchState, dx, dy, 
+                    const deltas = calculateShapeChanges(touchState, dx, dy,
                         this.props.displayToNativeRatioX, this.props.displayToNativeRatioY,
                         shape, this.props.width, this.props.height, dragLocation)
 
@@ -215,7 +215,7 @@ class ShapeEditorSvg extends Component {
         this.props.onShapeIsOutOfBoundsUpdates(false)
         this.setState({
             isDrawing: false,
-            dragOrigin: { x: 0, y: 0},
+            dragOrigin: { x: 0, y: 0 },
             previewShapeDimensions: this.previewShapeInitialDimensions(),
             shapeIndex: -1,
             shapeToRemoveIndex: -1,
@@ -233,19 +233,19 @@ class ShapeEditorSvg extends Component {
         switch (this.props.drawingShape) {
             case 'rect':
                 return (
-                    <Rect 
+                    <Rect
                         stroke="black"
                         strokeWidth={4 * this.props.displayToNativeRatioX}
                         fill="rgba(0, 0, 0, .5)"
                         {... this.state.previewShapeDimensions}
                     />
                 )
-            default: 
+            default:
                 return null
         }
     }
 
-    renderShapes() {        
+    renderShapes() {
         const shapeArray = []
         const convertObjectToComponent = (shape, index) => {
             const { type } = shape
@@ -264,7 +264,8 @@ class ShapeEditorSvg extends Component {
                                 this.closeLocations = R.set(R.lensProp(index), event.nativeEvent.layout, this.closeLocations)
                             }}
                             key={index}
-                            { ...shape }
+                            {...shape}
+                            nativeWidth={this.props.nativeWidth}
                             disabled={this.state.shapeToRemoveIndex === index}
                             displayToNativeRatioX={this.props.displayToNativeRatioX}
                             displayToNativeRatioY={this.props.displayToNativeRatioY}
@@ -272,7 +273,7 @@ class ShapeEditorSvg extends Component {
                             isDeletable={this.props.mode === 'erase'}
                             ref={ref => {
                                 if (ref) {
-                                        this.shapeRefs = R.set(R.lensProp(index), ref, this.shapeRefs)
+                                    this.shapeRefs = R.set(R.lensProp(index), ref, this.shapeRefs)
                                 }
                             }}
                         />
@@ -280,7 +281,7 @@ class ShapeEditorSvg extends Component {
                 }
             }
         }
-        
+
         R.mapObjIndexed(convertObjectToComponent, this.props.shapes)
         return shapeArray
     }
@@ -288,15 +289,15 @@ class ShapeEditorSvg extends Component {
     render() {
         const panHandlers = this.props.mode === 'draw' ? this.editPanResponder.panHandlers : this.erasePanResponder.panHandlers
         return (
-            <View { ...panHandlers } style={{height: this.props.height, width: this.props.width}}>
+            <View {...panHandlers} style={{ height: this.props.height, width: this.props.width }}>
                 <Svg
                     viewBox={this.props.viewBox}
                     height={this.props.height}
                     width={this.props.width}
                     key={`${Object.keys(this.props.shapes).length}${this.props.mode}`}
                 >
-                    { this.renderShapes() }
-                    { this.state.isDrawing && this.renderPreviewShape() }
+                    {this.renderShapes()}
+                    {this.state.isDrawing && this.renderPreviewShape()}
                 </Svg>
             </View>
         )
@@ -310,6 +311,7 @@ ShapeEditorSvg.propTypes = {
     viewBox: PropTypes.string,
     height: PropTypes.number,
     width: PropTypes.number,
+    nativeWidth: PropTypes.number,
     mode: PropTypes.string,
     onShapeCreated: PropTypes.func,
     onShapeEdited: PropTypes.func,

--- a/src/components/Markings/components/SvgOverlay.js
+++ b/src/components/Markings/components/SvgOverlay.js
@@ -17,13 +17,13 @@ const INITIAL_SQUARE_SIDE = 2
 
 /**
  * This class sits over the image and has 3 different modes
- * 
+ *
  * Draw - The Svg layer responds to pan gestures and will draw shapes based on the users inputs.
  *        Please not there are two different SVGs that get drawn. The preview shapes and the actual shape.
  *        The preview shapes are just feedback for the shape the user will draw
- * 
+ *
  * Edit - The shapes drawn become editable. The user may move the shapes and change its size.
- * 
+ *
  * Delete - The shape becomes deletable.
  */
 class SvgOverlay extends Component {
@@ -39,17 +39,17 @@ class SvgOverlay extends Component {
             previewSquareWidth: INITIAL_SQUARE_SIDE,
             previewSquareHeight: INITIAL_SQUARE_SIDE,
             // These values are the ratios of the the images display sizes to the images native size
-            displayToNativeRatioX: props.nativeWidth/props.width,
-            displayToNativeRatioY: props.nativeHeight/props.height
+            displayToNativeRatioX: props.nativeWidth / props.width,
+            displayToNativeRatioY: props.nativeHeight / props.height
         }
-          
-          this.onShapeEdited = this.onShapeEdited.bind(this)
-          this.onShapeDeleted = this.onShapeDeleted.bind(this)
-          this.onShapeCreated = this.onShapeCreated.bind(this)
+
+        this.onShapeEdited = this.onShapeEdited.bind(this)
+        this.onShapeDeleted = this.onShapeDeleted.bind(this)
+        this.onShapeCreated = this.onShapeCreated.bind(this)
     }
 
     componentDidUpdate(prevProps) {
-        const sizeChange = 
+        const sizeChange =
             prevProps.width !== this.props.width ||
             prevProps.height !== this.props.height ||
             prevProps.nativeWidth !== this.props.nativeWidth ||
@@ -57,8 +57,8 @@ class SvgOverlay extends Component {
 
         if (sizeChange) {
             this.setState({
-                displayToNativeRatioX: this.props.nativeWidth/this.props.width,
-                displayToNativeRatioY: this.props.nativeHeight/this.props.height
+                displayToNativeRatioX: this.props.nativeWidth / this.props.width,
+                displayToNativeRatioY: this.props.nativeHeight / this.props.height
             })
         }
     }
@@ -76,15 +76,16 @@ class SvgOverlay extends Component {
     }
 
     render() {
-        const sizeStyle = {height: this.props.height, width: this.props.width}
+        const sizeStyle = { height: this.props.height, width: this.props.width }
         return (
             <View style={sizeStyle} >
                 <View style={[styles.absolute, sizeStyle]}>
-                    <ShapeEditorSvg 
+                    <ShapeEditorSvg
                         viewBox={`0 0 ${this.props.nativeWidth} ${this.props.nativeHeight}`}
                         height={this.props.height}
                         width={this.props.width}
                         shapes={this.props.shapes}
+                        nativeWidth={this.props.nativeWidth}
                         mode={this.props.mode}
                         onShapeEdited={this.onShapeEdited}
                         onShapeDeleted={this.onShapeDeleted}
@@ -100,10 +101,10 @@ class SvgOverlay extends Component {
         )
     }
 
-    onShapeEdited(shapeIndex, {dx, dy, dw, dh}) {
+    onShapeEdited(shapeIndex, { dx, dy, dw, dh }) {
         this.props.onShapeModified({
-            dx, 
-            dy, 
+            dx,
+            dy,
             dw,
             dh
         }, shapeIndex)

--- a/src/components/Markings/components/SvgOverlay.js
+++ b/src/components/Markings/components/SvgOverlay.js
@@ -17,13 +17,13 @@ const INITIAL_SQUARE_SIDE = 2
 
 /**
  * This class sits over the image and has 3 different modes
- * 
+ *
  * Draw - The Svg layer responds to pan gestures and will draw shapes based on the users inputs.
  *        Please not there are two different SVGs that get drawn. The preview shapes and the actual shape.
  *        The preview shapes are just feedback for the shape the user will draw
- * 
+ *
  * Edit - The shapes drawn become editable. The user may move the shapes and change its size.
- * 
+ *
  * Delete - The shape becomes deletable.
  */
 class SvgOverlay extends Component {
@@ -39,17 +39,17 @@ class SvgOverlay extends Component {
             previewSquareWidth: INITIAL_SQUARE_SIDE,
             previewSquareHeight: INITIAL_SQUARE_SIDE,
             // These values are the ratios of the the images display sizes to the images native size
-            displayToNativeRatioX: props.nativeWidth/props.width,
-            displayToNativeRatioY: props.nativeHeight/props.height
+            displayToNativeRatioX: props.nativeWidth / props.width,
+            displayToNativeRatioY: props.nativeHeight / props.height
         }
-          
-          this.onShapeEdited = this.onShapeEdited.bind(this)
-          this.onShapeDeleted = this.onShapeDeleted.bind(this)
-          this.onShapeCreated = this.onShapeCreated.bind(this)
+
+        this.onShapeEdited = this.onShapeEdited.bind(this)
+        this.onShapeDeleted = this.onShapeDeleted.bind(this)
+        this.onShapeCreated = this.onShapeCreated.bind(this)
     }
 
     componentDidUpdate(prevProps) {
-        const sizeChange = 
+        const sizeChange =
             prevProps.width !== this.props.width ||
             prevProps.height !== this.props.height ||
             prevProps.nativeWidth !== this.props.nativeWidth ||
@@ -57,8 +57,8 @@ class SvgOverlay extends Component {
 
         if (sizeChange) {
             this.setState({
-                displayToNativeRatioX: this.props.nativeWidth/this.props.width,
-                displayToNativeRatioY: this.props.nativeHeight/this.props.height
+                displayToNativeRatioX: this.props.nativeWidth / this.props.width,
+                displayToNativeRatioY: this.props.nativeHeight / this.props.height
             })
         }
     }
@@ -76,16 +76,17 @@ class SvgOverlay extends Component {
     }
 
     render() {
-        const sizeStyle = {height: this.props.height, width: this.props.width}
+        const sizeStyle = { height: this.props.height, width: this.props.width }
         return (
             <View style={sizeStyle} >
                 <View style={[styles.absolute, sizeStyle]}>
-                    <ShapeEditorSvg 
+                    <ShapeEditorSvg
                         viewBox={`0 0 ${this.props.nativeWidth} ${this.props.nativeHeight}`}
                         height={this.props.height}
                         width={this.props.width}
                         shapes={this.props.shapes}
                         mode={this.props.mode}
+                        nativeWidth={this.props.nativeWidth}
                         onShapeEdited={this.onShapeEdited}
                         onShapeDeleted={this.onShapeDeleted}
                         onShapeCreated={this.onShapeCreated}
@@ -100,10 +101,10 @@ class SvgOverlay extends Component {
         )
     }
 
-    onShapeEdited(shapeIndex, {dx, dy, dw, dh}) {
+    onShapeEdited(shapeIndex, { dx, dy, dw, dh }) {
         this.props.onShapeModified({
-            dx, 
-            dy, 
+            dx,
+            dy,
             dw,
             dh
         }, shapeIndex)
@@ -123,7 +124,7 @@ const styles = {
 SvgOverlay.propTypes = {
     height: PropTypes.number,
     width: PropTypes.number,
-    nativeWidth: PropTypes.number,
+    nativeWidth: PropTypes.number.isRequired,
     nativeHeight: PropTypes.number,
     color: PropTypes.string,
     drawingShape: PropTypes.oneOf(['rect']),

--- a/src/components/Markings/components/SvgOverlay.js
+++ b/src/components/Markings/components/SvgOverlay.js
@@ -17,13 +17,13 @@ const INITIAL_SQUARE_SIDE = 2
 
 /**
  * This class sits over the image and has 3 different modes
- *
+ * 
  * Draw - The Svg layer responds to pan gestures and will draw shapes based on the users inputs.
  *        Please not there are two different SVGs that get drawn. The preview shapes and the actual shape.
  *        The preview shapes are just feedback for the shape the user will draw
- *
+ * 
  * Edit - The shapes drawn become editable. The user may move the shapes and change its size.
- *
+ * 
  * Delete - The shape becomes deletable.
  */
 class SvgOverlay extends Component {
@@ -39,17 +39,17 @@ class SvgOverlay extends Component {
             previewSquareWidth: INITIAL_SQUARE_SIDE,
             previewSquareHeight: INITIAL_SQUARE_SIDE,
             // These values are the ratios of the the images display sizes to the images native size
-            displayToNativeRatioX: props.nativeWidth / props.width,
-            displayToNativeRatioY: props.nativeHeight / props.height
+            displayToNativeRatioX: props.nativeWidth/props.width,
+            displayToNativeRatioY: props.nativeHeight/props.height
         }
-
-        this.onShapeEdited = this.onShapeEdited.bind(this)
-        this.onShapeDeleted = this.onShapeDeleted.bind(this)
-        this.onShapeCreated = this.onShapeCreated.bind(this)
+          
+          this.onShapeEdited = this.onShapeEdited.bind(this)
+          this.onShapeDeleted = this.onShapeDeleted.bind(this)
+          this.onShapeCreated = this.onShapeCreated.bind(this)
     }
 
     componentDidUpdate(prevProps) {
-        const sizeChange =
+        const sizeChange = 
             prevProps.width !== this.props.width ||
             prevProps.height !== this.props.height ||
             prevProps.nativeWidth !== this.props.nativeWidth ||
@@ -57,8 +57,8 @@ class SvgOverlay extends Component {
 
         if (sizeChange) {
             this.setState({
-                displayToNativeRatioX: this.props.nativeWidth / this.props.width,
-                displayToNativeRatioY: this.props.nativeHeight / this.props.height
+                displayToNativeRatioX: this.props.nativeWidth/this.props.width,
+                displayToNativeRatioY: this.props.nativeHeight/this.props.height
             })
         }
     }
@@ -76,16 +76,15 @@ class SvgOverlay extends Component {
     }
 
     render() {
-        const sizeStyle = { height: this.props.height, width: this.props.width }
+        const sizeStyle = {height: this.props.height, width: this.props.width}
         return (
             <View style={sizeStyle} >
                 <View style={[styles.absolute, sizeStyle]}>
-                    <ShapeEditorSvg
+                    <ShapeEditorSvg 
                         viewBox={`0 0 ${this.props.nativeWidth} ${this.props.nativeHeight}`}
                         height={this.props.height}
                         width={this.props.width}
                         shapes={this.props.shapes}
-                        nativeWidth={this.props.nativeWidth}
                         mode={this.props.mode}
                         onShapeEdited={this.onShapeEdited}
                         onShapeDeleted={this.onShapeDeleted}
@@ -101,10 +100,10 @@ class SvgOverlay extends Component {
         )
     }
 
-    onShapeEdited(shapeIndex, { dx, dy, dw, dh }) {
+    onShapeEdited(shapeIndex, {dx, dy, dw, dh}) {
         this.props.onShapeModified({
-            dx,
-            dy,
+            dx, 
+            dy, 
             dw,
             dh
         }, shapeIndex)

--- a/src/utils/__tests__/shape-utils-test.js
+++ b/src/utils/__tests__/shape-utils-test.js
@@ -1,0 +1,59 @@
+import { calculateDeleteButtonPosition } from '../shapeUtils'
+
+describe('calculateDeleteButtonPosition', () => {
+  describe('when the rects are in the corners', () => {
+    const topRight = calculateDeleteButtonPosition(
+      80, 0, 20, 20, 100, 1
+    )
+    expect(topRight).toEqual({ x: 54, y: 0 })
+
+    const bottomRight = calculateDeleteButtonPosition(
+      80, 80, 20, 20, 100, 1
+    )
+    expect(bottomRight).toEqual({ x: 54, y: 67 })
+
+    const bottomLeft = calculateDeleteButtonPosition(
+      0, 80, 20, 20, 100, 1
+    )
+    expect(bottomLeft).toEqual({ x: 20, y: 67 })
+
+    const topLeft = calculateDeleteButtonPosition(
+      0, 0, 20, 20, 100, 1
+    )
+    expect(topLeft).toEqual({ x: 20, y: 0 })
+  })
+
+  describe('when the rects are flipped and in the corners', () => {
+    const topRight = calculateDeleteButtonPosition(
+      100, 20, -20, -20, 100, 1
+    )
+    expect(topRight).toEqual({ x: 54, y: 0 })
+
+    const bottomRight = calculateDeleteButtonPosition(
+      100, 100, -20, -20, 100, 1
+    )
+    expect(bottomRight).toEqual({ x: 54, y: 67 })
+
+    const bottomLeft = calculateDeleteButtonPosition(
+      20, 100, -20, -20, 100, 1
+    )
+    expect(bottomLeft).toEqual({ x: 20, y: 67 })
+
+    const topLeft = calculateDeleteButtonPosition(
+      20, 20, -20, -20, 100, 1
+    )
+    expect(topLeft).toEqual({ x: 20, y: 0 })
+  })
+
+  describe('when the rects fill the screen', () => {
+    const fullScreen = calculateDeleteButtonPosition(
+      0, 0, 100, 100, 100, 1
+    )
+    expect(fullScreen).toEqual({ x: 0, y: 0 })
+
+    const fullScreenFlipped = calculateDeleteButtonPosition(
+      100, 100, -100, -100, 100, 1
+    )
+    expect(fullScreenFlipped).toEqual({ x: 0, y: 0 })
+  })
+})

--- a/src/utils/__tests__/shape-utils-test.js
+++ b/src/utils/__tests__/shape-utils-test.js
@@ -1,59 +1,57 @@
-import { calculateDeleteButtonPosition } from '../shapeUtils'
+import {calculateDeleteButtonPosition} from '../shapeUtils'
 
-describe('calculateDeleteButtonPosition', () => {
-  describe('when the rects are in the corners', () => {
-    const topRight = calculateDeleteButtonPosition(
-      80, 0, 20, 20, 100, 1
+it('moves delete button when the rects are in the corners', () => {
+    const topRightCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        80, 0, 20, 20, 100, 1
     )
-    expect(topRight).toEqual({ x: 54, y: 0 })
+    expect(topRightCornerDeleteButtonPosition).toEqual({x: 54, y: 0})
 
-    const bottomRight = calculateDeleteButtonPosition(
-      80, 80, 20, 20, 100, 1
+    const bottomRightCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        80, 80, 20, 20, 100, 1
     )
-    expect(bottomRight).toEqual({ x: 54, y: 67 })
+    expect(bottomRightCornerDeleteButtonPosition).toEqual({x: 54, y: 67})
 
-    const bottomLeft = calculateDeleteButtonPosition(
-      0, 80, 20, 20, 100, 1
+    const bottomLeftCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        0, 80, 20, 20, 100, 1
     )
-    expect(bottomLeft).toEqual({ x: 20, y: 67 })
+    expect(bottomLeftCornerDeleteButtonPosition).toEqual({x: 20, y: 67})
 
-    const topLeft = calculateDeleteButtonPosition(
-      0, 0, 20, 20, 100, 1
+    const topLeftCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        0, 0, 20, 20, 100, 1
     )
-    expect(topLeft).toEqual({ x: 20, y: 0 })
-  })
+    expect(topLeftCornerDeleteButtonPosition).toEqual({x: 20, y: 0})
+})
 
-  describe('when the rects are flipped and in the corners', () => {
-    const topRight = calculateDeleteButtonPosition(
-      100, 20, -20, -20, 100, 1
+it('moves delete button when the rects are flipped and in the corners', () => {
+    const topRightCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        100, 20, -20, -20, 100, 1
     )
-    expect(topRight).toEqual({ x: 54, y: 0 })
+    expect(topRightCornerDeleteButtonPosition).toEqual({x: 54, y: 0})
 
-    const bottomRight = calculateDeleteButtonPosition(
-      100, 100, -20, -20, 100, 1
+    const bottomRightCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        100, 100, -20, -20, 100, 1
     )
-    expect(bottomRight).toEqual({ x: 54, y: 67 })
+    expect(bottomRightCornerDeleteButtonPosition).toEqual({x: 54, y: 67})
 
-    const bottomLeft = calculateDeleteButtonPosition(
-      20, 100, -20, -20, 100, 1
+    const bottomLeftCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        20, 100, -20, -20, 100, 1
     )
-    expect(bottomLeft).toEqual({ x: 20, y: 67 })
+    expect(bottomLeftCornerDeleteButtonPosition).toEqual({x: 20, y: 67})
 
-    const topLeft = calculateDeleteButtonPosition(
-      20, 20, -20, -20, 100, 1
+    const topLeftCornerDeleteButtonPosition = calculateDeleteButtonPosition(
+        20, 20, -20, -20, 100, 1
     )
-    expect(topLeft).toEqual({ x: 20, y: 0 })
-  })
+    expect(topLeftCornerDeleteButtonPosition).toEqual({x: 20, y: 0})
+})
 
-  describe('when the rects fill the screen', () => {
-    const fullScreen = calculateDeleteButtonPosition(
-      0, 0, 100, 100, 100, 1
+it('moves delete button when the rects fill the screen', () => {
+    const fullScreenDeleteButtonPosition = calculateDeleteButtonPosition(
+        0, 0, 100, 100, 100, 1
     )
-    expect(fullScreen).toEqual({ x: 0, y: 0 })
+    expect(fullScreenDeleteButtonPosition).toEqual({x: 0, y: 0})
 
-    const fullScreenFlipped = calculateDeleteButtonPosition(
-      100, 100, -100, -100, 100, 1
+    const fullScreenFlippedDeleteButtonPosition = calculateDeleteButtonPosition(
+        100, 100, -100, -100, 100, 1
     )
-    expect(fullScreenFlipped).toEqual({ x: 0, y: 0 })
-  })
+    expect(fullScreenFlippedDeleteButtonPosition).toEqual({x: 0, y: 0})
 })

--- a/src/utils/shapeUtils.js
+++ b/src/utils/shapeUtils.js
@@ -11,15 +11,37 @@ export const drawingTouchState = {
     bottomRight: true
 }
 
+export const calculateDeleteButtonPosition = (
+    x, y, width, height, nativeWidth, displayToNativeRatioX
+) => {
+    const buttonRadius = 26 * displayToNativeRatioX;
+
+    const absoluteX = width > 0 ? x : x + width
+    const shapeRightX = absoluteX + Math.abs(width)
+    const newX = shapeRightX > nativeWidth - buttonRadius
+        ? Math.max(absoluteX - buttonRadius, 0)
+        : shapeRightX
+
+
+    const absoluteY = height > 0 ? y : y + height
+    const newY = newX === 0 || absoluteY < buttonRadius
+        ? absoluteY
+        : absoluteY - buttonRadius / 2
+
+    return { x: newX, y: newY }
+}
+
+
+
 /**
  * This function receives and x,y coordinate and determines if
  * the coordinate is within the bounds of the shape.
- * 
- * @param {x coordinate of touch} xCoord 
- * @param {y coordinate of touch} yCoord 
- * @param {location data of shape} shape 
+ *
+ * @param {x coordinate of touch} xCoord
+ * @param {y coordinate of touch} yCoord
+ * @param {location data of shape} shape
  */
-export const isCoordinateWithinSquare = (xCoord, yCoord, {x, y, width, height}) => {
+export const isCoordinateWithinSquare = (xCoord, yCoord, { x, y, width, height }) => {
     const withinX = xCoord > x && xCoord < (x + width)
     const withinY = yCoord > y && yCoord < (y + height)
     return withinX && withinY
@@ -27,28 +49,28 @@ export const isCoordinateWithinSquare = (xCoord, yCoord, {x, y, width, height}) 
 
 /**
  * This function determines if any part of the shape passed in is out of bounds
- * 
- * @param {{x, y, width, height} dimensions of the shape} shape 
- * @param {{width, height} dimensions of the bounds} bounds 
+ *
+ * @param {{x, y, width, height} dimensions of the shape} shape
+ * @param {{width, height} dimensions of the bounds} bounds
  */
-export const isShapeOutOfBounds = (shape, bounds, bufferConstant=0) => {
-    const {x, y, width, height} = shape
+export const isShapeOutOfBounds = (shape, bounds, bufferConstant = 0) => {
+    const { x, y, width, height } = shape
     const isPastLeftBound = (width > 0 ? x : parseFloat(x) + parseFloat(width)) < 0 - bufferConstant
     const isPastUpperBound = (height > 0 ? y : parseFloat(y) + parseFloat(height)) < 0 - bufferConstant
     const isPastRightBound = (width > 0 ? parseFloat(x) + parseFloat(width) : x) > bounds.width + bufferConstant
-    const isPastBottomBound = ( height > 0 ? parseFloat(y) + parseFloat(height) : y) > bounds.height + bufferConstant
+    const isPastBottomBound = (height > 0 ? parseFloat(y) + parseFloat(height) : y) > bounds.height + bufferConstant
 
     return isPastLeftBound || isPastUpperBound || isPastRightBound || isPastBottomBound
 }
 
 /**
  * This function determines whether a touch coordinate is touching the permeter of an object
- * 
- * @param {x coordinate of touch} xCoord 
- * @param {y coordinate of touch} yCoord 
- * @param {dimensions of perimeter} shapePerimeter 
+ *
+ * @param {x coordinate of touch} xCoord
+ * @param {y coordinate of touch} yCoord
+ * @param {dimensions of perimeter} shapePerimeter
  */
-const isCoordinateTouchingPerimeter = (xCoord, yCoord, {x, y ,width, height}) => {
+const isCoordinateTouchingPerimeter = (xCoord, yCoord, { x, y, width, height }) => {
     const touchRange = 10
     const isCoordinateTouching = (touchCoordinate, targeCoordinate) => {
         return touchCoordinate > (targeCoordinate - touchRange) && touchCoordinate < (targeCoordinate + touchRange)
@@ -69,25 +91,25 @@ const isCoordinateTouchingPerimeter = (xCoord, yCoord, {x, y ,width, height}) =>
 /**
  * This function receives an x,y coordinate and determines if the touch is touching
  * any of the corners passed into the object
- * 
- * @param {x coordinate of the touch event} xCoord 
- * @param {y coordinate of the touch event} yCoord 
- * @param {This objects container data on the locations of the corners of a shape. } corners 
+ *
+ * @param {x coordinate of the touch event} xCoord
+ * @param {y coordinate of the touch event} yCoord
+ * @param {This objects container data on the locations of the corners of a shape. } corners
  */
 const analyzeCorners = (xCoord, yCoord, corners) => {
     return R.mapObjIndexed((val) => {
         const isWithinCorner = isCoordinateWithinSquare(xCoord, yCoord, val)
         return isWithinCorner
-    },corners)
+    }, corners)
 }
 
 /**
  * This function receives an x,y coordinate touch event, a shape coordinate
  * and corner coordinates.
- * 
+ *
  * The function returns an analysis object based on where the touch is relative to the shape.
- * 
- * An example of this object would look like the following: 
+ *
+ * An example of this object would look like the following:
  * {
  *  upperLeft: false,
  *  upperRight: false,
@@ -96,13 +118,13 @@ const analyzeCorners = (xCoord, yCoord, corners) => {
  *  withinSquare: true,
  *  perimeterOnly: false
  * }
- * 
+ *
  * This object essentially explains which part of the shape the user is touching
- * 
- * @param {x coordinate of touch} xCoord 
- * @param {y coordinate of touch} yCoord 
- * @param {coordinate information for shape} shape 
- * @param {coordinate information for shape's corners} corners 
+ *
+ * @param {x coordinate of touch} xCoord
+ * @param {y coordinate of touch} yCoord
+ * @param {coordinate information for shape} shape
+ * @param {coordinate information for shape's corners} corners
  */
 export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
     const analyzedCorners = analyzeCorners(xCoord, yCoord, corners)
@@ -110,7 +132,7 @@ export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
     const touchingPerimeter = isCoordinateTouchingPerimeter(xCoord, yCoord, shape)
     const withinSquare = touchingCorners || touchingPerimeter
     return {
-        ... analyzedCorners,
+        ...analyzedCorners,
         withinSquare,
         perimeterOnly: !touchingCorners && touchingPerimeter
     }
@@ -119,17 +141,17 @@ export const analyzeCoordinateWithShape = (xCoord, yCoord, shape, corners) => {
 /**
  * Calculates the deltas that should be applied to an object
  * based on a touch events dx and dy.
- * 
- * @param {An object that explains where the user is touching} touchState 
- * @param {Touch dx} dx 
- * @param {Touch dy} dy 
- * @param {The ratio that the shape should scale in the x direction} scaleRatioX 
- * @param {The ratio that the shape should scale in the y direction} scaleRatioY 
+ *
+ * @param {An object that explains where the user is touching} touchState
+ * @param {Touch dx} dx
+ * @param {Touch dy} dy
+ * @param {The ratio that the shape should scale in the x direction} scaleRatioX
+ * @param {The ratio that the shape should scale in the y direction} scaleRatioY
  */
-export const calculateShapeChanges = (  touchState, touchDx, touchDy, scaleRatioX, 
-                                        scaleRatioY, shapeCoordinates, svgWidth, svgHeight,
-                                        dragOrigin ) => {
-    const {upperLeft, bottomLeft, upperRight, bottomRight, perimeterOnly} = touchState
+export const calculateShapeChanges = (touchState, touchDx, touchDy, scaleRatioX,
+    scaleRatioY, shapeCoordinates, svgWidth, svgHeight,
+    dragOrigin) => {
+    const { upperLeft, bottomLeft, upperRight, bottomRight, perimeterOnly } = touchState
     const scaledX = touchDx * scaleRatioX
     const scaledY = touchDy * scaleRatioY
 
@@ -161,23 +183,23 @@ export const calculateShapeChanges = (  touchState, touchDx, touchDy, scaleRatio
         deltas.dh = scaledY
     }
 
-    return constrainDeltasToRange(  touchState, deltas, shapeCoordinates,
-                                    svgWidth * scaleRatioX, svgHeight * scaleRatioY,
-                                    { x: dragOrigin.x * scaleRatioX, y: dragOrigin.y * scaleRatioY } )
+    return constrainDeltasToRange(touchState, deltas, shapeCoordinates,
+        svgWidth * scaleRatioX, svgHeight * scaleRatioY,
+        { x: dragOrigin.x * scaleRatioX, y: dragOrigin.y * scaleRatioY })
 }
 
 /**
  * This function constrains a change in a shape to 2d bounds
- * @param {Where the user is touching} touchState 
- * @param {Proposed Deltas to a shape} deltas 
- * @param {Shape coordinates} shapeCoordinates 
- * @param {X bound} maxX 
- * @param {Y bound} maxY 
+ * @param {Where the user is touching} touchState
+ * @param {Proposed Deltas to a shape} deltas
+ * @param {Shape coordinates} shapeCoordinates
+ * @param {X bound} maxX
+ * @param {Y bound} maxY
  * @param {Where the drag event originated} dragOrigin
  */
 const constrainDeltasToRange = (touchState, deltas, shapeCoordinates, maxX, maxY, dragOrigin) => {
     const { upperLeft, bottomLeft, upperRight, bottomRight } = touchState
-    const { dx, dy, dw, dh } = deltas 
+    const { dx, dy, dw, dh } = deltas
     const { x, y, height, width } = shapeCoordinates
 
     const xIsOutOfRange = distanceFromRange(dragOrigin.x, 0, maxX) !== 0
@@ -185,7 +207,7 @@ const constrainDeltasToRange = (touchState, deltas, shapeCoordinates, maxX, maxY
 
     const constrainedDeltas = { dx, dy, dw, dh }
     if (xIsOutOfRange) {
-        const isXInverted = width + dw < 0 
+        const isXInverted = width + dw < 0
         if (upperLeft || bottomLeft) {
             constrainedDeltas.dx = (isXInverted ? maxX : 0) - x
             constrainedDeltas.dw = -constrainedDeltas.dx


### PR DESCRIPTION
Fixes #301

# The Problem

Right now, when using the drawing tools, if your rectangle is too close to the edge, the `x` button will be partially, and sometimes completely, invisible. 

![Screen Shot 2020-03-28 at 3 46 32 PM](https://user-images.githubusercontent.com/3202211/77835578-53a32080-710b-11ea-8c88-d9c3b9685a16.png)

# The Solution

![Screen Shot 2020-03-28 at 4 47 47 PM](https://user-images.githubusercontent.com/3202211/77836888-7d624480-7117-11ea-8235-073405dfcca5.png)


I've added some logic to where: 

- If the button is partially covered by the top of the screen, move it down a bit
- If the button is ever partially covered due to the right of the screen, move the button to the left side of the rect. 
- If the rect is wide enough that the close button can't fit on the either side, move it to the inside left

# In action. 

To make sure , I was sure to create the rects by dragging from a different corner. I also tested on multiple iPhone simulators
![Screen Shot 2020-03-28 at 4 43 35 PM](https://user-images.githubusercontent.com/3202211/77836869-396f3f80-7117-11ea-8ac9-da7f0c0fc4f4.png)
![Screen Shot 2020-03-28 at 4 43 54 PM](https://user-images.githubusercontent.com/3202211/77836876-4f7d0000-7117-11ea-878b-f6a6b5243384.png)
![Screen Shot 2020-03-28 at 4 43 35 PM](https://user-images.githubusercontent.com/3202211/77836878-59066800-7117-11ea-9d7b-d096409b8aee.png)
![Screen Shot 2020-03-28 at 4 46 26 PM](https://user-images.githubusercontent.com/3202211/77836883-6de2fb80-7117-11ea-9e29-5313fe51949a.png)
![Screen Shot 2020-03-28 at 4 46 54 PM](https://user-images.githubusercontent.com/3202211/77836885-720f1900-7117-11ea-852e-987af429552b.png)

# Review Checklist

I haven't tested android because I think I need permissions that I don't have.  

- [X] Does it work on iOS - Tested on iPhone 6, 8, and 11
- [ ] Does it work in Android 
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Are tests passing?

Due to autoformatting, this PR looks bigger than it actually is. I'd recommend ignoring whitespace :) https://github.com/zooniverse/mobile/pull/320/files?diff=unified&w=1
