### PR TITLE
Enable gifs on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -175,6 +175,8 @@ dependencies {
     implementation project(':@react-native-community_blur')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation 'com.facebook.fresco:animated-gif:2.0.0' //gif support
+
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -142,11 +142,11 @@ PODS:
     - react-native-google-analytics-bridge/Core (= 5.9.0)
   - react-native-google-analytics-bridge/Core (5.9.0):
     - React
-  - react-native-netinfo (4.7.0):
+  - react-native-netinfo (4.6.1):
     - React
   - react-native-splash-screen (3.2.0):
     - React
-  - react-native-webview (7.6.0):
+  - react-native-webview (7.5.1):
     - React
   - React-RCTActionSheet (0.60.0):
     - React-Core (= 0.60.0)
@@ -184,10 +184,16 @@ PODS:
     - Firebase/Messaging (~> 6.13.0)
     - React
     - RNFBApp
+  - RNSentry (1.7.0):
+    - React
+    - Sentry (~> 5.1.8)
   - RNSVG (9.13.3):
     - React
   - RNVectorIcons (7.0.0):
     - React
+  - Sentry (5.1.10):
+    - Sentry/Core (= 5.1.10)
+  - Sentry/Core (5.1.10)
   - SocketRocket (0.5.1)
   - yoga (0.60.0.React)
 
@@ -223,6 +229,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
+  - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - SocketRocket
@@ -246,6 +253,7 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - Protobuf
+    - Sentry
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -309,6 +317,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBMessaging:
     :path: "../node_modules/@react-native-firebase/messaging"
+  RNSentry:
+    :path: "../node_modules/@sentry/react-native"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   RNVectorIcons:
@@ -346,9 +356,9 @@ SPEC CHECKSUMS:
   React-jsinspector: d4ed52225912efe0019bb7f1a225aec20f23049a
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-google-analytics-bridge: 95334ced9e20c9e7a23a2b7a6e2ab878b0acdc61
-  react-native-netinfo: ddaca8bbb9e6e914b1a23787ccb879bc642931c9
+  react-native-netinfo: 16c6408c311572f17f9ffc3fa12614489307b6cf
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-webview: db4682f1698ab4b17a5e88f951031d203ff8aea8
+  react-native-webview: b7ad1323338cb52e370bb07d6141308953ff2440
   React-RCTActionSheet: b27ff3cf3a68f917c46d2b94abf938b625b96570
   React-RCTAnimation: 9e4708e5bd65fca8285ce7c0aa076f3f4fa5c2f8
   React-RCTBlob: 6eafcc3a24f33785692a7be24918ade607bc8719
@@ -360,11 +370,13 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4ee1cf208ab17a50fafb1c16ffe28fe594a64e4f
   React-RCTWebSocket: fca087d583724aa0e5fef7d911f0f2a28d0f2736
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
-  RNDeviceInfo: 75dac2d7cd6b638b512cc9266ce48a39661fed0e
+  RNDeviceInfo: fd8296de6fca8b743cdc499b896f48e8a9f1faf5
   RNFBApp: 7b539bb25520fa73d6a240f5c6ea569e27683645
   RNFBMessaging: c55142d3b2d34d706bf12bd5eef9ef35254c2df1
+  RNSentry: 05192c14c02562eb7810d6ac3c227b68e76cfb9c
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
   RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
+  Sentry: 8715e88b813bde9ad37aead365d5b04ac7302153
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
   yoga: 616fde658be980aa60a2158835170f3f9c2d04b4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7532,11 +7532,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
-    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -7911,15 +7906,6 @@
       "dev": true,
       "requires": {
         "default-require-extensions": "^1.0.0"
-      }
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -10280,11 +10266,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
     "denodeify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
@@ -11974,18 +11955,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-      "requires": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -12189,11 +12158,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -16439,21 +16403,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -16999,11 +16948,6 @@
         "yargs": "^9.0.0"
       }
     },
-    "metro-memory-fs": {
-      "version": "0.48.5",
-      "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.48.5.tgz",
-      "integrity": "sha512-dxN0dBtMOR1CvyRIOM/NE+uFirybWb4y2PZke0Z8bpYn6ttmv8ZF3PVdFxJf9v9irVBSOIPD0mD5zllxQkXzhg=="
-    },
     "metro-minify-uglify": {
       "version": "0.51.1",
       "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.51.1.tgz",
@@ -17412,16 +17356,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-      "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-      "requires": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
-      }
-    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -17655,27 +17589,6 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        }
       }
     },
     "optionator": {
@@ -18452,11 +18365,6 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
       }
-    },
-    "react-clone-referenced-element": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
-      "integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
     },
     "react-deep-force-update": {
       "version": "1.1.2",
@@ -19396,8 +19304,7 @@
       "from": "github:zooniverse/react-native-deck-swiper",
       "requires": {
         "prop-types": "15.5.10",
-        "react": "^16.6.3",
-        "react-native": "^0.57.8"
+        "react": "^16.6.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -19989,23 +19896,18 @@
             "metro": "^0.48.1",
             "metro-babel-register": "^0.48.1",
             "metro-core": "^0.48.1",
-            "metro-memory-fs": "^0.48.1",
             "mime": "^1.3.4",
             "minimist": "^1.2.0",
             "mkdirp": "^0.5.1",
             "morgan": "^1.9.0",
             "node-fetch": "^2.2.0",
             "node-notifier": "^5.2.1",
-            "npmlog": "^2.0.4",
             "opn": "^3.0.2",
-            "optimist": "^0.6.1",
             "plist": "^3.0.0",
             "pretty-format": "^4.2.1",
             "promise": "^7.1.1",
             "prop-types": "^15.5.8",
-            "react-clone-referenced-element": "^1.0.1",
             "react-devtools-core": "^3.4.2",
-            "react-timer-mixin": "^0.13.2",
             "regenerator-runtime": "^0.11.0",
             "rimraf": "^2.5.4",
             "semver": "^5.0.3",
@@ -20584,11 +20486,6 @@
         "react-is": "^16.8.6",
         "scheduler": "^0.13.6"
       }
-    },
-    "react-timer-mixin": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
-      "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
     },
     "react-transform-hmr": {
       "version": "1.0.4",


### PR DESCRIPTION
+ Gifs are not automatically supported on Android in react-native: you have to include a library specifically to support them.

Fixes # 332.

# What this change should allow you to do:

1. Run the Android Emulator (while it is pointing to staging)
2. Go to "Beta Projects"
3. Find the project called "Project with all mobile workflows"
4. Click the "multi answer question" workflow and go through the tutorial. I have the subject set for this workflow set to include gifs!
5. Go through the tutorial, get to the images and ensure that they move!

**This PR is not working if** the images _show up_ but don't _move_.

This was working already, but for peace of mind, please feel free to also try this exact same series of steps on an iOS Simulator to ensure the images move for everybody :)


# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

# My goals for this PR:

There's no code here—only a line added to the Android build.gradle file and subsequent dependency file updates—so there isn't much to have goals about. We _did_ want this working because it increases the number of projects that can use the mobile app with the existing workflows until I get around to issue #290 (grazie @wgranger) and add video support.

