### PR TITLE
Get image sizing to work (?) on Android (confirm with Cliff with staging data)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20090,6 +20090,11 @@
       "resolved": "https://registry.npmjs.org/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.11.tgz",
       "integrity": "sha512-ZCisGUFpPchHXsjT7ZI0anlSLPgcTmjRKXqpVnPu3RDWFXfKjuL4zpY57DX4Y8YgGZCpbf9fApN7KjVYody2Mw=="
     },
+    "react-native-image-size": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-native-image-size/-/react-native-image-size-1.1.3.tgz",
+      "integrity": "sha512-jJvN6CjXVAm69LAVZNV7m7r50Qk9vuPZwLyrbs/k31/3Xs8bZyVCdvfP44FuBisITn/yFsiOo6i8NPrFBPH20w=="
+    },
     "react-native-loading-spinner-overlay": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/react-native-loading-spinner-overlay/-/react-native-loading-spinner-overlay-0.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-native-extended-stylesheet": "^0.8.1",
     "react-native-google-analytics-bridge": "^5.0.0",
     "react-native-image-pan-zoom": "^2.0.16",
+    "react-native-image-size": "^1.1.3",
     "react-native-loading-spinner-overlay": "^0.5.2",
     "react-native-router-flux": "4.0.6",
     "react-native-simple-markdown": "*1.1.0",

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -117,11 +117,10 @@ class DrawingClassifier extends Component {
         const {subject} = this.props
         if (prevProps.subject !== subject && subject) {
             this.props.imageActions.loadImageToCache(subject.displays[0].src).then(localImagePath => {
-                if (Platform.OS === 'android') { 
-                    ImageSize.getSize(localImagePath).then(size => {
-                        const width = size.width
-                        const height = size.height
-
+                if (Platform.OS === 'android') {
+                    // This isn't using the cache because Image.getSize can't fetch from a local
+                    // path on Android. We tried EVERYTHING.
+                    Image.getSize(subject.displays[0].src, (width, height) => {
                         this.props.classifierActions.setSubjectSizeInWorkflow(subject.id, {width, height})
                     })
                 } else {    //this is the appropriate behavior. It's just broken on Android right now.

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -11,6 +11,7 @@ import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import R from 'ramda'
 import DeviceInfo from 'react-native-device-info';
+import ImageSize from 'react-native-image-size'
 
 import ClassificationPanel from '../classifier/ClassificationPanel'
 import DrawingClassifierSubject from './DrawingClassifierSubject'
@@ -100,7 +101,12 @@ class DrawingClassifier extends Component {
     }
 
     submitClassification() {
-        this.props.classifierActions.submitDrawingClassification(this.props.shapes, this.props.workflow, this.props.subject, this.state.subjectDimensions)
+        this.props.classifierActions.submitDrawingClassification(
+            this.props.shapes,
+            this.props.workflow,
+            this.props.subject,
+            this.state.subjectDimensions
+        )
         this.setState({
             modalHasBeenClosedOnce: false,
             imageIsLoaded: false
@@ -111,10 +117,13 @@ class DrawingClassifier extends Component {
         const {subject} = this.props
         if (prevProps.subject !== subject && subject) {
             this.props.imageActions.loadImageToCache(subject.displays[0].src).then(localImagePath => {
-                if (Platform.OS === 'android') {
-                    width = 200
-                    height = 260
-                    this.props.classifierActions.setSubjectSizeInWorkflow(subject.id, {width, height})
+                if (Platform.OS === 'android') { 
+                    ImageSize.getSize(localImagePath).then(size => {
+                        const width = size.width
+                        const height = size.height
+
+                        this.props.classifierActions.setSubjectSizeInWorkflow(subject.id, {width, height})
+                    })
                 } else {    //this is the appropriate behavior. It's just broken on Android right now.
                     Image.getSize(localImagePath, (width, height) => {
                         this.props.classifierActions.setSubjectSizeInWorkflow(subject.id, {width, height})

--- a/src/components/Markings/DrawingClassifier.js
+++ b/src/components/Markings/DrawingClassifier.js
@@ -11,7 +11,6 @@ import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import R from 'ramda'
 import DeviceInfo from 'react-native-device-info';
-import ImageSize from 'react-native-image-size'
 
 import ClassificationPanel from '../classifier/ClassificationPanel'
 import DrawingClassifierSubject from './DrawingClassifierSubject'


### PR DESCRIPTION
Fixes https://github.com/zooniverse/mobile/issues/359 (see also: https://zooniverse.slack.com/archives/CM645BF2L/p1611671917008600)

# What this change should allow you to do:

Get accurate image size info from android devices.

# Review Checklist

- [ x ] Does it work in Android and iOS?
- [ x ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ x ] Are tests passing?

# My goals for this PR:

