### PR TITLE
Add task type checks to isValidQuestionWorkflow and isValidMobileWorkflow tests

### DIFF
--- a/src/utils/__tests__/utils-test.js
+++ b/src/utils/__tests__/utils-test.js
@@ -69,6 +69,26 @@ it('gets a subject location ', () => {
   expect(getSubjectLocation(subject)).toEqual(returnSubject)
 })
 
+it('passes a good drawing workflow', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    help: 'Good luck!',
+    instruction: 'Draw on the cat!',
+    tools: [
+      {
+        color: '#00ff00',
+        details: [],
+        label: 'Rectangle Tool',
+        type: 'rectangle'
+      }
+    ],
+    type: 'drawing',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeTruthy()
+})
+
 it('passes a good single question workflow', () => {
   let testWorkflow = Object.assign({}, mockWorkflow)
   testWorkflow.first_task = 'T0'
@@ -118,6 +138,125 @@ it('passes a good multiple question workflow', () => {
   }
   
   expect(isValidMobileWorkflow(testWorkflow)).toBeTruthy()
+})
+
+it('fails a bad drawing workflow with more than one task', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks = {
+    T0: {
+      help: 'Good luck!',
+      instruction: 'Draw on the cat!',
+      next: 'T1',
+      tools: [
+        {
+          color: '#00ff00',
+          details: [],
+          label: 'Rectangle Tool',
+          type: 'rectangle'
+        }
+      ],
+      type: 'drawing',
+    },
+    T1: {
+      answers: [
+        { label: 'Yes' },
+        { label: 'No' }
+      ],
+      help: 'Good luck!',
+      question: 'Cats?',
+      type: 'single',
+    }
+  }
+
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad drawing workflow with undefined first task', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.tasks['T0'] = {
+    help: 'Good luck!',
+    instruction: 'Draw on the cat!',
+    tools: [
+      {
+        color: '#00ff00',
+        details: [],
+        label: 'Rectangle Tool',
+        type: 'rectangle'
+      }
+    ],
+    type: 'drawing',
+  }
+  testWorkflow.first_task = ''
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad drawing workflow with instructions length > 200', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    help: 'Good luck!',
+    instruction: 'i'.repeat(201),
+    tools: [
+      {
+        color: '#00ff00',
+        details: [],
+        label: 'Rectangle Tool',
+        type: 'rectangle'
+      }
+    ],
+    type: 'drawing',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad drawing workflow with more than one drawing tool', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    help: 'Good luck!',
+    instruction: 'Draw on the cat!',
+    tools: [
+      {
+        color: '#00ff00',
+        details: [],
+        label: 'Rectangle Tool',
+        type: 'rectangle'
+      },
+      {
+        color: '#ff0000',
+        details: [],
+        label: 'Rectangle Tool',
+        type: 'rectangle'
+      },
+    ],
+    type: 'drawing',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad drawing workflow with any tool other than rectangle', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    help: 'Good luck!',
+    instruction: 'Draw on the cat!',
+    tools: [
+      {
+        color: '#ff0000',
+        details: [],
+        label: 'Point Tool',
+        size: 'small',
+        type: 'point'
+      }
+    ],
+    type: 'drawing',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
 })
 
 it('fails a bad question workflow with more than one task', () => {

--- a/src/utils/__tests__/utils-test.js
+++ b/src/utils/__tests__/utils-test.js
@@ -3,6 +3,15 @@ import { isValidEmail } from '../is-valid-email'
 import { isValidLogin } from '../is-valid-login'
 import { generateSessionID } from '../session'
 import getSubjectLocation from '../get-subject-location'
+import { isValidMobileWorkflow } from '../workflow-utils'
+
+let mockWorkflow = {
+  active: true,
+  first_task: '',
+  id: '1234',
+  mobile_friendly: true,
+  tasks: {},
+}
 
 it('passes a good email', () => {
   let email = 'me@zooniverse.org'
@@ -58,4 +67,134 @@ it('gets a subject location ', () => {
     src: 'https://kitty.org/cat.jpg'
   }]
   expect(getSubjectLocation(subject)).toEqual(returnSubject)
+})
+
+it('passes a good single question workflow', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' },
+      { label: 'Maybe' }
+    ],
+    help: 'Good luck!',
+    question: 'Cats?',
+    type: 'single',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeTruthy()
+})
+
+it('adds workflow type "swipe" to an appropriate workflow', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' }
+    ],
+    help: 'Good luck!',
+    question: 'Cats?',
+    type: 'single',
+  }
+
+  expect(isValidMobileWorkflow(testWorkflow)).toBeTruthy()
+  expect(testWorkflow.type).toEqual('swipe')
+})
+
+it('passes a good multiple question workflow', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' },
+      { label: 'Maybe' }
+    ],
+    help: 'Good luck!',
+    question: 'Cats?',
+    type: 'multiple',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeTruthy()
+})
+
+it('fails a bad question workflow with more than one task', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks = {
+    T0: {
+      answers: [
+        { label: 'Yes', next: 'T1' },
+        { label: 'No', next: 'T1' },
+        { label: 'Maybe', next: 'T1' }
+      ],
+      help: 'Good luck!',
+      question: 'Cats?',
+      type: 'multiple',
+    },
+    T1: {
+      answers: [
+        { label: 'Yes' },
+        { label: 'No' }
+      ],
+      help: 'Good luck!',
+      question: 'Cats?',
+      type: 'single',
+    },
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad question workflow with undefined first task', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' }
+    ],
+    help: 'Good luck!',
+    question: 'Cats?',
+    type: 'single',
+  }
+  testWorkflow.first_task = ''
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad question workflow with question length > 200', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' }
+    ],
+    help: 'Good luck!',
+    question: '?'.repeat(201),
+    type: 'single',
+  }
+  
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
+})
+
+it('fails a bad question workflow with feedback', () => {
+  let testWorkflow = Object.assign({}, mockWorkflow)
+  testWorkflow.first_task = 'T0'
+  testWorkflow.tasks['T0'] = {
+    answers: [
+      { label: 'Yes' },
+      { label: 'No' }
+    ],
+    feedback: {
+      enabled: true
+    },
+    help: 'Good luck!',
+    question: 'Cats?',
+    type: 'single',
+  }
+
+  expect(isValidMobileWorkflow(testWorkflow)).toBeFalsy()
 })

--- a/src/utils/workflow-utils.js
+++ b/src/utils/workflow-utils.js
@@ -28,8 +28,17 @@ const isValidQuestionWorkflow = (workflow) => {
   if (!workflow.first_task) {
     return false
   }
+  
   const firstTask = workflow.tasks[workflow.first_task]
+  
+  if (firstTask === undefined) {
+    return false
+  }
 
+  if (firstTask.type !== 'single' && firstTask.type !== 'multiple') {
+    return false
+  }
+  
   const hasSingleTask = workflowHasSingleTask(workflow)
 
   const shortcut = workflow.tasks[firstTask.unlinkedTask]


### PR DESCRIPTION
Fixes #360.

There's no immediate/live/active issue related to this, but opening for consideration to include in the upcoming release.

Background: invalid drawing task workflows were returning false when validated with the drawing task workflow validation, but then passed to the question task workflow validation which would throw an unhandled error, preventing current and subsequent workflow loading.

# What this change should allow you to do:
- no immediate change to user experience, though #360 was previously preventing workflows from loading, the workflow that caused the issue was manually fixed
- load all valid mobile workflows if a new invalid task workflow is created

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?

# My goals for this PR:
- add task type checks in the question task workflow validation, so an invalid drawing or any invalid task type returns false from the question task workflow validation
- adds tests for valid and invalid question (single and multiple) and drawing task workflows
