### PR TITLE
Enable markdown rendering on answer buttons so they can include images

### DIFF
--- a/src/components/classifier/ClassifierButton.js
+++ b/src/components/classifier/ClassifierButton.js
@@ -32,6 +32,7 @@ class ClassifierButton extends Component {
                 style={[this.props.style, styles.button, this.buttonStyle]}
             >
                 <SizedMarkdown
+                    forButton={true}
                     inMuseumMode={this.props.inMuseumMode}
                 >
                     {this.props.text}

--- a/src/components/classifier/ClassifierButton.js
+++ b/src/components/classifier/ClassifierButton.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import EStyleSheet from 'react-native-extended-stylesheet'
 import DeviceInfo from 'react-native-device-info'
 
+import SizedMarkdown from '../common/SizedMarkdown'
 import FontedText from '../common/FontedText'
 import * as colorModes from '../../displayOptions/colorModes'
 
@@ -30,9 +31,11 @@ class ClassifierButton extends Component {
                 activeOpacity={0.5}
                 style={[this.props.style, styles.button, this.buttonStyle]}
             >
-                <FontedText style={[styles.buttonText, this.textStyle]}>
+                <SizedMarkdown
+                    inMuseumMode={this.props.inMuseumMode}
+                >
                     {this.props.text}
-                </FontedText>
+                </SizedMarkdown>
             </TouchableOpacity>
         )
     }
@@ -42,6 +45,7 @@ class AnswerButton extends ClassifierButton {
     setAdditionalStyles() {
         this.buttonStyle = []
         this.textStyle = []
+        this.buttonStyle.push({padding: 10})
         this.textStyle.push(styles.whiteButtonText)
 
         if (this.props.deselected) {

--- a/src/components/common/SizedMarkdown.js
+++ b/src/components/common/SizedMarkdown.js
@@ -47,17 +47,21 @@ class SizedMarkdown extends Component {
 
     render() {
         const { viewDimensions } = this.state
-        const imageHeight = Math.min(viewDimensions.height, 80)
+
+        //We limit the width and height so any button images
+        const buttonImageHeight = Math.min(viewDimensions.height, 80)
+        const buttonImageWidth = Math.min(viewDimensions.width, 100)
+
         const customStyles = {
             text: {
                 fontFamily: 'Karla',
                 fontSize: isTablet ? 22 : 14,
                 fontWeight: isTablet ? 'bold' : 'normal',
-                color: colorModes.instructionsColorFor(this.props.inMuseumMode)
+                color: colorModes.instructionsColorFor(this.props.inMuseumMode),
             },
             image: {
-                width: viewDimensions.width,
-                height: imageHeight
+                width: this.props.forButton ? buttonImageWidth : viewDimensions.width,
+                height: this.props.forButton ? buttonImageHeight : viewDimensions.height,
             }
         }
         return (
@@ -75,10 +79,12 @@ const isTablet = DeviceInfo.isTablet()
 SizedMarkdown.propTypes = {
     children: PropTypes.node,
     inMuseumMode: PropTypes.bool,
+    forButton: PropTypes.bool,
 }
 
 SizedMarkdown.defaultProps = {
-    inMuseumMode: false
+    inMuseumMode: false,
+    forButton: false
 }
 
 export default SizedMarkdown

--- a/src/components/common/SizedMarkdown.js
+++ b/src/components/common/SizedMarkdown.js
@@ -52,12 +52,19 @@ class SizedMarkdown extends Component {
         const buttonImageHeight = Math.min(viewDimensions.height, 80)
         const buttonImageWidth = Math.min(viewDimensions.width, 100)
 
+        // Stylistic vertical centering options weren't affecting this view
+        // so we're vertically centering text manually on buttons.
+        // DRAWBACK: text longer than one line will look weird
+        const fontSize = isTablet ? 22 : 14
+        const textCenteringHeight = (buttonImageHeight / 2) - (fontSize / 2)
+
         const customStyles = {
             text: {
                 fontFamily: 'Karla',
-                fontSize: isTablet ? 22 : 14,
+                fontSize: fontSize,
                 fontWeight: isTablet ? 'bold' : 'normal',
                 color: colorModes.instructionsColorFor(this.props.inMuseumMode),
+                paddingTop: this.props.forButton ? textCenteringHeight : 0,
             },
             image: {
                 width: this.props.forButton ? buttonImageWidth : viewDimensions.width,

--- a/src/components/common/SizedMarkdown.js
+++ b/src/components/common/SizedMarkdown.js
@@ -47,6 +47,7 @@ class SizedMarkdown extends Component {
 
     render() {
         const { viewDimensions } = this.state
+        const imageHeight = Math.min(viewDimensions.height, 80)
         const customStyles = {
             text: {
                 fontFamily: 'Karla',
@@ -56,7 +57,7 @@ class SizedMarkdown extends Component {
             },
             image: {
                 width: viewDimensions.width,
-                height: viewDimensions.height
+                height: imageHeight
             }
         }
         return (

--- a/src/displayOptions/colorModes.js
+++ b/src/displayOptions/colorModes.js
@@ -129,10 +129,13 @@ export function textColorFor(museumMode) {
 }
 
 export function instructionsColorFor(museumMode) {
+    // Keeping this function for styling consistency and flexibility, but
+    // With the button colors we've chosen right now, white
+    // Is higher contrast than black even in not-museum-mode
     return switchOn(
         museumMode,
         'white',
-        'black'
+        'white'
     )
 }
 


### PR DESCRIPTION
+ image size will be limited to 80 points in height and to the width of the container, and will maintain their aspect ratio (so, sized to whichever between width and height hits its limit first)..
+ answer button has some padding such that no markdown image or text runs RIGHT up to the edge of the button and obfuscates its borders
+ markdown button text is vertically centered. None of the options for vertical alignment styling appeared to be doing anything (I  tried several). After a 3 hour time box, I switched to manually pushing text down to the center of the button. The drawback here is that buttons with text that is longer than one line will have all that text in the bottom half of the button. Happy to continue to devote time here, but I recommend only doing it if _a lot_ of our projects like to wax poetic in their button text.

Fixes #374.

So some gigantic, square images in button markdown will look like so:

<img width="329" alt="Screen Shot 2021-09-29 at 10 57 30 AM" src="https://user-images.githubusercontent.com/5744164/135306312-563b03e2-4fd4-4c74-b628-af7e30e32e36.png">

As opposed to prior:
<img width="339" alt="Screen Shot 2021-09-21 at 1 05 11 PM" src="https://user-images.githubusercontent.com/5744164/134223796-3454a528-984d-4720-ad4e-4f64b4dae701.png">

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?
