### PR TITLE
Remove console.log from ProjectTile component

### DIFF
--- a/src/components/projects/ProjectTile.js
+++ b/src/components/projects/ProjectTile.js
@@ -132,7 +132,6 @@ class ProjectTile extends Component {
             this.props.containsNativeWorkflows,
             this.props.containsMultipleNativeWorkflows
         )
-        console.log(this.props.project.display_name + " workflows all complete: " + shouldDisplayIsOutOfData.toString())
 
         const avatarUri = R.prop('avatar_src', this.props.project);
         const avatarSource = avatarUri !== undefined ? { uri: avatarUri } : require('../../../images/teal-wallpaper.png');


### PR DESCRIPTION
Noticed while testing updates. It's helpful to see what this console log is showing - `this.props.project.display_name + " workflows all complete: " + shouldDisplayIsOutOfData.toString()` so I could see good reason to leave this in, in which case feel free to close this. I was about to ask or open a related issue, but it took just as long to open this tiny PR, so here we are!

# Review Checklist

- [x] Does it work in Android and iOS?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are tests passing?

# My goals for this PR:

