### PR TITLE
Disable build system deprecation error in xcode

### DIFF
--- a/ios/ZooniverseMobile.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/ZooniverseMobile.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -4,6 +4,8 @@
 <dict>
 	<key>BuildSystemType</key>
 	<string>Original</string>
+	<key>DisableBuildSystemDeprecationDiagnostic</key>
+	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<true/>
 	<key>PreviewsEnabled</key>


### PR DESCRIPTION
When running the app using XCode I hit an error related to the build system will be deprecated. 

This error can be resolved by changing the following setting within Xcode (bottom left red arrow):
![Screen Shot 2021-10-30 at 4 20 44 PM](https://user-images.githubusercontent.com/12118751/139558677-047f454e-8e0b-4a3b-9b60-1f03e8384cf5.png)

I think updating `ios/ZooniverseMobile.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings` accordingly will automatically enable the setting noted for this project.

This change is not necessary, but might make it easier (one less thing to worry about to get up and running) for other devs to get started.

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?

# My goals for this PR:

