### PR TITLE
Text stopped showing up in the app because it was being displayed in …

### DIFF
--- a/src/components/classifier/ClassifierButton.js
+++ b/src/components/classifier/ClassifierButton.js
@@ -18,7 +18,7 @@ class ClassifierButton extends Component {
 
     setAdditionalStyles() {
         this.buttonStyle = []
-        this.textStyle = []
+        this.textStyle = {}
     }
 
     render() {
@@ -33,7 +33,7 @@ class ClassifierButton extends Component {
             >
                 <SizedMarkdown
                     forButton={true}
-                    inMuseumMode={this.props.inMuseumMode}
+                    style={this.textStyle}
                 >
                     {this.props.text}
                 </SizedMarkdown>
@@ -45,9 +45,12 @@ class ClassifierButton extends Component {
 class AnswerButton extends ClassifierButton {
     setAdditionalStyles() {
         this.buttonStyle = []
-        this.textStyle = []
+        this.textStyle = {}
         this.buttonStyle.push({padding: 10})
-        this.textStyle.push(styles.whiteButtonText)
+        this.textStyle = {
+            ...this.textStyle,
+            ...styles.whiteButtonText
+        }
 
         if (this.props.deselected) {
             this.buttonStyle.push(colorModes.disabledButtonStyleFor(this.props.inMuseumMode))
@@ -62,9 +65,12 @@ class AnswerButton extends ClassifierButton {
 class GuideButton extends ClassifierButton {
     setAdditionalStyles() {
         this.buttonStyle = []
-        this.textStyle = []
+        this.textStyle = {}
 
-        this.textStyle.push(colorModes.selectedTextColorFor(this.props.inMuseumMode))
+        this.textStyle = {
+            ...this.textStyle,
+            ...colorModes.selectedTextColorFor(this.props.inMuseumMode)
+        }
         this.buttonStyle.push(styles.guideButton)
         this.buttonStyle.push(colorModes.guideButtonStyleFor(this.props.inMuseumMode))
     }
@@ -73,8 +79,11 @@ class GuideButton extends ClassifierButton {
 class SubmitButton extends ClassifierButton {
     setAdditionalStyles() {
         this.buttonStyle = []
-        this.textStyle = []
-        this.textStyle.push(colorModes.submitButtonTextColorFor(this.props.inMuseumMode))
+        this.textStyle = {}
+        this.textStyle = {
+            ...this.textStyle,
+            ...colorModes.submitButtonTextColorFor(this.props.inMuseumMode)
+        }
 
         if (this.props.disabled) {
             this.buttonStyle.push(colorModes.disabledSubmitButtonStyleFor(this.props.inMuseumMode))
@@ -87,9 +96,12 @@ class SubmitButton extends ClassifierButton {
 class SwipeButton extends ClassifierButton {
     setAdditionalStyles() {
         this.buttonStyle = []
-        this.textStyle = []
+        this.textStyle = {}
 
-        this.textStyle.push(styles.whiteButtonText)
+        this.textStyle = {
+            ...this.textStyle,
+            ...styles.whiteButtonText
+        }
         this.buttonStyle.push(colorModes.unselectedButtonStyleFor(this.props.inMuseumMode))
     }
 }

--- a/src/components/common/SizedMarkdown.js
+++ b/src/components/common/SizedMarkdown.js
@@ -60,17 +60,21 @@ class SizedMarkdown extends Component {
 
         const customStyles = {
             text: {
-                fontFamily: 'Karla',
-                fontSize: fontSize,
-                fontWeight: isTablet ? 'bold' : 'normal',
-                color: colorModes.instructionsColorFor(this.props.inMuseumMode),
-                paddingTop: this.props.forButton ? textCenteringHeight : 0,
+                ...{
+                    fontFamily: 'Karla',
+                    fontSize: fontSize,
+                    fontWeight: isTablet ? 'bold' : 'normal',
+                    color: 'black',
+                    paddingTop: this.props.forButton ? textCenteringHeight : 0,
+                },
+                ...this.props.style
             },
             image: {
                 width: this.props.forButton ? buttonImageWidth : viewDimensions.width,
                 height: this.props.forButton ? buttonImageHeight : viewDimensions.height,
             }
         }
+
         return (
             <View onLayout={this.onViewLayout}>
                 <Markdown rules={markdownImageRule} styles={customStyles}>
@@ -87,6 +91,7 @@ SizedMarkdown.propTypes = {
     children: PropTypes.node,
     inMuseumMode: PropTypes.bool,
     forButton: PropTypes.bool,
+    style: PropTypes.object,
 }
 
 SizedMarkdown.defaultProps = {


### PR DESCRIPTION
…white on a white background. It turned out that the text styling information was not being passed to the SizedMarkdown componen, which is responsible for displaying the text. This fixes that.

+ SizedMarkdown has no inMuseumMode property. It's not clear that it ever did. That should be removed wherever it is declared.

Fixes # .

# What this change should allow you to do:

Invision Mock-ups: 

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?

# My goals for this PR:

