### PR TITLE
Upgrade `react-native-google-analytics-bridge` to v7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21764,9 +21764,9 @@
       }
     },
     "react-native-google-analytics-bridge": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-google-analytics-bridge/-/react-native-google-analytics-bridge-5.9.0.tgz",
-      "integrity": "sha512-VsfovNdqoTGn3nwvB7G0bencRxtSOPby81lnOmTR+NdkPlgQqYKSrK0wg4HwsOx63d3YQAn5hcwbHOQwMJTIaw=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-google-analytics-bridge/-/react-native-google-analytics-bridge-7.1.0.tgz",
+      "integrity": "sha512-HtFrsTk9fGXumYUKCxS8gzFobAS+vcBMzSgpYN+YQGPAvK4xgogTpz1u19BxzjsjV85xm+aaIA/t0SkRDXVjEQ=="
     },
     "react-native-image-pan-zoom": {
       "version": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-native-device-info": "2.1.2",
     "react-native-drawer": "^2.3.0",
     "react-native-extended-stylesheet": "^0.8.1",
-    "react-native-google-analytics-bridge": "^5.0.0",
+    "react-native-google-analytics-bridge": "^7.1.0",
     "react-native-image-pan-zoom": "^2.0.16",
     "react-native-image-size": "^1.1.3",
     "react-native-loading-spinner-overlay": "^0.5.2",

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -13,7 +13,7 @@ import StyledText from './StyledText'
 import { setNavbarSettingsForPage } from '../actions/navBar'
 import PageKeys from '../constants/PageKeys'
 
-GoogleAnalytics.trackEvent('view', 'About page')
+// GoogleAnalytics.trackEvent('view', 'About page')
 
 class About extends React.Component {
 

--- a/src/components/Discipline.js
+++ b/src/components/Discipline.js
@@ -18,7 +18,7 @@ class Discipline extends Component {
   }
 
   handleClick() {
-    GoogleAnalytics.trackEvent('view', this.props.tag)
+    // GoogleAnalytics.trackEvent('view', this.props.tag)
     const navigationProps = {selectedProjectTag: this.props.tag, color: this.props.color}
     Actions.ProjectList(navigationProps)
   }

--- a/src/components/NotificationModal.js
+++ b/src/components/NotificationModal.js
@@ -62,7 +62,7 @@ class NotificationModal extends Component {
   }
 
   handleClick() {
-    GoogleAnalytics.trackEvent('view from notification', this.props.notificationProject.display_name)
+    // GoogleAnalytics.trackEvent('view from notification', this.props.notificationProject.display_name)
 
     const zurl=`http://zooniverse.org/projects/${this.props.notificationProject.slug}`
     Linking.canOpenURL(zurl).then(supported => {

--- a/src/components/ProjectDisciplines.js
+++ b/src/components/ProjectDisciplines.js
@@ -25,8 +25,8 @@ import { setNavbarSettingsForPage } from '../actions/navBar'
 import PageKeys from '../constants/PageKeys'
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 
-GoogleAnalytics.setTrackerId(GLOBALS.GOOGLE_ANALYTICS_TRACKING)
-GoogleAnalytics.trackEvent('view', 'Home')
+// GoogleAnalytics.setTrackerId(GLOBALS.GOOGLE_ANALYTICS_TRACKING)
+// GoogleAnalytics.trackEvent('view', 'Home')
 
 const mapStateToProps = (state) => {
   const nativePreviewProjects = state.projects.previewProjectList.filter(

--- a/src/components/Publication.js
+++ b/src/components/Publication.js
@@ -19,7 +19,7 @@ class Publication extends Component {
   }
 
   handlePress() {
-    GoogleAnalytics.trackEvent('view', 'publication')
+    // GoogleAnalytics.trackEvent('view', 'publication')
 
     const zurl=this.props.publication.href
     Linking.canOpenURL(zurl).then(supported => {

--- a/src/components/PublicationList.js
+++ b/src/components/PublicationList.js
@@ -18,7 +18,7 @@ import { addIndex, defaultTo, keys, map } from 'ramda'
 import { setNavbarSettingsForPage } from '../actions/navBar'
 import PageKeys from '../constants/PageKeys';
 
-GoogleAnalytics.trackEvent('view', 'Publication List')
+// GoogleAnalytics.trackEvent('view', 'Publication List')
 
 const mapStateToProps = (state) => ({
   user: state.user,

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -80,7 +80,7 @@ export class Register extends React.Component {
   }
 
   handleOpenPrivacyPolicy() {
-    GoogleAnalytics.trackEvent('view', 'Privacy Policy')
+    // GoogleAnalytics.trackEvent('view', 'Privacy Policy')
 
     const url='https://www.zooniverse.org/privacy'
     Linking.canOpenURL(url).then(supported => {

--- a/src/components/SideDrawerContent.js
+++ b/src/components/SideDrawerContent.js
@@ -173,7 +173,7 @@ const SocialMediaLink = ({mediaLink, iconName}) =>
   </TouchableOpacity>
 
 const openSocialMediaLink = (link) => {
-  GoogleAnalytics.trackEvent('view', link)
+  // GoogleAnalytics.trackEvent('view', link)
 
   Linking.canOpenURL(link).then(supported => {
     if (supported) {

--- a/src/components/projects/ProjectList.js
+++ b/src/components/projects/ProjectList.js
@@ -22,7 +22,7 @@ import * as projectDisplay from '../../displayOptions/projectDisplay'
 
 import theme from '../../theme'
 
-GoogleAnalytics.trackEvent('view', 'Project')
+// GoogleAnalytics.trackEvent('view', 'Project')
 
 const mapStateToProps = (state, ownProps) => {
     const { selectedProjectTag } = ownProps;

--- a/src/components/projects/ProjectTile.js
+++ b/src/components/projects/ProjectTile.js
@@ -96,7 +96,7 @@ class ProjectTile extends Component {
     _onMainViewPress() {
         const { workflows, display_name, redirect } = this.props.project
         
-        GoogleAnalytics.trackEvent('view', display_name)
+        // GoogleAnalytics.trackEvent('view', display_name)
 
         if (workflows.length > 1) {
             Animated.timing(this.state.popupOpacity, { toValue: 1, duration: 300 }).start(() => {

--- a/src/components/settings/Settings.js
+++ b/src/components/settings/Settings.js
@@ -21,7 +21,7 @@ import theme from '../../theme'
 import { setNavbarSettingsForPage } from '../../actions/navBar'
 import PageKeys from '../../constants/PageKeys'
 
-GoogleAnalytics.trackEvent('view', 'Notification Settings')
+// GoogleAnalytics.trackEvent('view', 'Notification Settings')
 
 const mapStateToProps = (state) => {
   const {


### PR DESCRIPTION
I was able to get the `video-subjects` branch running for Android after editing the `node_modules/react-native-google-analytics-bridge/android/build.gradle` code to use `implementation` instead of `compile`.

The (deprecated) dependency fixes the issue in v7.0.0 ([link to repo tag](https://github.com/idehub/react-native-google-analytics-bridge/releases/tag/v7.0.0)).

However, after upgrading, if I attempt to refactor the related code to [use as suggested](https://github.com/idehub/react-native-google-analytics-bridge/releases/tag/v7.0.0), tests fail with `_reactNativeGoogleAnalyticsBridge.GoogleAnalyticsTracker is not a constructor`.

I can dig into this more, but first want to check if this helps @chelseatroy run the app for Android locally?