### PR TITLE
Fix Android build for API 30 and 31

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,7 +76,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-        entryFile: "index.js"
+        entryFile: "index.js",
+        enableHermes: true, // clean and rebuild if changing (/mobile: cd android && ./gradlew clean)
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -175,6 +176,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.facebook.fresco:animated-gif:2.0.0' //gif support
+    implementation 'com.facebook.soloader:soloader:0.9.0+'
     implementation 'io.sentry:sentry-android:5.2.4'
 
 


### PR DESCRIPTION
Fixes issue with API 30 and API 31 builds.
API 29 builds previously and continue to work.

Related GitHub issues:
 - https://github.com/facebook/SoLoader/issues/55#issuecomment-653890808
 - https://github.com/facebook/react-native/issues/25537

# What this change should allow you to do:
- run app on API 30 and API 31 devices

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?