### PR TITLE
Adjusted AndroidManifest.xml to 1) Fix android 13 crash and 2) remove…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
 
     <application
       android:name=".MainApplication"
-      android:largeHeap="true"
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
@@ -30,23 +29,18 @@
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@mipmap/ic_notification" />
 
-        <activity
-            android:name=".LaunchScreen"
-            android:theme="@style/SplashTheme"
-            android:label="@string/app_name"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize"
         android:exported="true"
+        android:screenOrientation="portrait"
       >
+       <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
         <intent-filter>
             <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Fixes android 13 crash. The MainActivity needed to be set to MAIN instead of LaunchScreen. Removed LaunchScreen (not needed in newer versions and causes issues). Also removed setting for largeHeap. This shouldn't be there unless it's needed as it can cause performance issues.