### PR TITLE
Update package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "npm start",
-    "android": "npm run android",
-    "ios": "npm run ios",
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
     "test": "NODE_ENV=staging jest --runInBand",
     "test:watch": "npm test -- --watch"
   },


### PR DESCRIPTION
Update package.json scripts to include `react-native`. Current scripts don't run react-native server or react-native builds as expected.

# What this change should allow you to do:
run `npm start` to start react-native local server, `npm android` to build for android, or `npm ios` to build for ios.

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?
