### PR TITLE
Only tag projects with museum mode if user is logged in.

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -84,10 +84,10 @@ export function fetchProjects() {
                     let projectDetailCalls = []
                     projectDetailCalls.push(getWorkflowsForProjects(allProjects))
                     const avatarCall = getAvatarsForProjects(allProjects)
-                    const museumModeCall = tagMuseumRoleForProjects(allProjects)
-
+                    
                     projectDetailCalls = projectDetailCalls.concat(avatarCall)
                     if (userIsLoggedIn) {
+                      const museumModeCall = tagMuseumRoleForProjects(allProjects)
                       projectDetailCalls = projectDetailCalls.concat(museumModeCall)
                     }
                     // Then load the avatars and workflows

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -113,7 +113,8 @@ export class Tutorial extends Component {
                         ref={ref => this.swiper = ref}
                         showsPagination={false}
                         loop={false}
-                        onIndexChanged={(index) => this.setState({step: index})}
+                        onIndexChanged={(index) => this.setState({ step: index })}
+                        loadMinimal={true}
                     >
                         {tutorialSteps}
                     </Swiper>

--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -113,8 +113,7 @@ export class Tutorial extends Component {
                         ref={ref => this.swiper = ref}
                         showsPagination={false}
                         loop={false}
-                        onIndexChanged={(index) => this.setState({ step: index })}
-                        loadMinimal={true}
+                        onIndexChanged={(index) => this.setState({step: index})}
                     >
                         {tutorialSteps}
                     </Swiper>


### PR DESCRIPTION
Disabled museum mode if user is not logged in. This prevents the state where a logged out user clicks on a project and sees 1) no back button 2) generic title 3) different, darker styling. Projects that are marked museum mode will still have these differences if the user is logged in.

