### PR TITLE
Added property loadMinimal={true} to Swiper fixes the glitch where ea…

### DIFF
--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -113,7 +113,8 @@ export class Tutorial extends Component {
                         ref={ref => this.swiper = ref}
                         showsPagination={false}
                         loop={false}
-                        onIndexChanged={(index) => this.setState({step: index})}
+                        onIndexChanged={(index) => this.setState({ step: index })}
+                        loadMinimal={true}
                     >
                         {tutorialSteps}
                     </Swiper>


### PR DESCRIPTION
Tutorial slider had a glitch where each time you went to a new slide the positioning would increasingly get misaligned. 

Researching issues in the swiper library I found https://github.com/leecade/react-native-swiper/issues/569#issuecomment-888039704. I applied this property and the issue went away.