### PR TITLE
Update eslint parser to show errors in code.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:@typescript-eslint/recommended',
   ],
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',


### PR DESCRIPTION
Errors were not showing in vscode. For example you could remove an import and no error would show. The parser in the eslintrc.js file needed to be updated to the correct parser. Now vscode will show errors like undefined variables and missing imports. 
