### PR TITLE
Filter out finished projects.

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -90,12 +90,14 @@ export function fetchProjects() {
                       const museumModeCall = tagMuseumRoleForProjects(allProjects)
                       projectDetailCalls = projectDetailCalls.concat(museumModeCall)
                     }
+
+                    const filterOutFinished = allProjects.filter(project => project.state !== 'finished')
                     // Then load the avatars and workflows
                     Promise.all(projectDetailCalls)
                         .then(() => {
-                            dispatch(addProjects(allProjects))
+                            dispatch(addProjects(filterOutFinished))
                             dispatch(addProjectsSuccess);
-                            resolve(allProjects)
+                            resolve(filterOutFinished)
                         })
                         .catch((error) => {
                             dispatch(addProjectsFailure);


### PR DESCRIPTION
The goal is to filter out the finished projects so they are not shown.

There were 2 approaches I tried:
1) Call for projects with separate API calls where state=live & state=paused. Pros: by not calling for finished it saved 1 extra api call in total. Cons: By separating the calls, the order of the projects was different than before.
2) Call for all projects and filter out finished. Pros: order stays the same (except for not showing finished projects). Cons: 1 extra api call.

The API calls are called in parallel so there was no performance gain with method 1 so I oped for method 2 to keep the order of projects the same as before.