### PR TITLE
Fixes error where field guide breaks when there are no icons.

### DIFF
--- a/src/components/classifier/FieldGuideItemDetail.js
+++ b/src/components/classifier/FieldGuideItemDetail.js
@@ -18,7 +18,7 @@ const FieldGuideItemDetail = (props) => {
     return (
         <ScrollView style={styles.itemDetailContainer}>
             <View onLayout={props.setHeaderHeight}>
-                {props.icons[props.item.icon] && props.icons[props.item.icon].src
+                {props.icons?.[props.item.icon]?.src
                     ? <SizedImage
                         source={{uri: props.icons[props.item.icon].src}}
                         maxHeight={ITEM_ICON_RADIUS * 2}


### PR DESCRIPTION
Fixes bug @mcbouslog found while reviewing https://github.com/zooniverse/mobile/pull/514#pullrequestreview-1904331529. The field guide expects an icons property to be an object but in some cases it is undefined which causes a breaking change. This code fix uses optional chaining which allows it to safely access nested object properties, methods, and array elements without having to explicitly check for null or undefined at each level of the chain.

@lcjohnso This was a quick code fix but let me know if you want me to create a GitHub issue to track this.

Additional: I think the code has been like this for quite a while and I couldn't find any production projects that were missing icons that would've caused this on production. I see the error in Sentry for when it happened for Mark and me, but could not find any other instances of it.