### PR TITLE
Clear timeout in modal component. Remove shouldAnimateOverlay.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,8 +79,8 @@ android {
         applicationId "com.zooniversemobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 86
-        versionName "2.12.0"
+        versionCode 87
+        versionName "2.12.1"
     }
     signingConfigs {
         debug {

--- a/ios/ZooniverseMobile.xcodeproj/project.pbxproj
+++ b/ios/ZooniverseMobile.xcodeproj/project.pbxproj
@@ -598,7 +598,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZooniverseMobile/ZooniverseMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 888MXXMABP;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
@@ -606,7 +606,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 2.12.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -628,14 +628,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZooniverseMobile/ZooniverseMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 888MXXMABP;
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 2.12.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/src/components/classifier/FeedbackModal.js
+++ b/src/components/classifier/FeedbackModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Modal, View, StyleSheet, TouchableOpacity } from 'react-native';
 
 import Icon from 'react-native-vector-icons/Fontisto';
@@ -13,18 +13,25 @@ const FeedbackModal = ({
   onClose = false,
   inMuseumMode = false,
 }) => {
+  const timeoutRef = useRef(null);
+
   useEffect(() => {
     if (inMuseumMode) {
-      setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         close();
       }, 10000);
     }
-  });
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [inMuseumMode]);
 
   const close = () => {
-    if (onClose) {
-      onClose();
-    }
+    clearTimeout(timeoutRef.current);
+    onClose();
   };
 
   return (

--- a/src/components/classifier/SwipeClassifier.js
+++ b/src/components/classifier/SwipeClassifier.js
@@ -136,8 +136,6 @@ export class SwipeClassifier extends React.Component {
 
     renderCard = (subject, index) => {
         const seenThisSession = R.indexOf(subject.id, this.props.subjectsSeenThisSession) >= 0
-        const shouldAnimateOverlay = this.props.subjectLists[this.state.swiperIndex].id === subject.id
-        
         // If mutliple images, only show top swipe card to prevent preformance issues.
         if (subject.displays.length > 1 && index !== this.state.swiperIndex) return null;
 
@@ -146,7 +144,6 @@ export class SwipeClassifier extends React.Component {
             seenThisSession={seenThisSession}
             inMuseumMode={this.props.route.params.project.in_museum_mode}
             panX={this.state.panX}
-            shouldAnimateOverlay={shouldAnimateOverlay}
             answers={this.props.answers}
             onExpandButtonPressed={this.expandImage}
             subjectDisplayWidth={this.state.swiperDimensions.width}


### PR DESCRIPTION
This bug was a combination of two separate issues and would've only occurred in museum mode. 

1) There was some code from before the reskinning that was no longer needed and could've been removed. It was comparing the swiper index to the subject list to display the subject. At some point the swiper index got higher than the highest value in the subject list and caused the crash.

2) In the feedback modal is a timeout that dismisses the modal after 10 seconds in museum mode. It was not being cleared when it was finished and would increase the swipe index, causing the swipe index to be higher than the length of the subject list and therefore attempting to call the id on a subject list object that didn't exist.

The fix was to 1) remove the code not needed and 2) clear to the timeout during cleanup (standard practice for timeouts).

Update: Also updated version/build numbers since this will get released as a hotfix.