### PR TITLE
Show video player when tutorial step is mp4.

### DIFF
--- a/src/components/classifier/Tutorial.js
+++ b/src/components/classifier/Tutorial.js
@@ -31,6 +31,7 @@ export class Tutorial extends Component {
                     markdownContent={step.content}
                     inMuseumMode={this.props.inMuseumMode}
                     mediaUri={this.props.tutorial.mediaResources && this.props.tutorial.mediaResources[step.media] ? this.props.tutorial.mediaResources[step.media].src : null}
+                    isActive={this.state.step === index}
                 />
             )
         })

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -32,7 +32,7 @@ class TutorialStep extends Component {
     }
 
     render() {
-        const isVideo = this.props.mediaUri.slice(this.props.mediaUri.length - 4).match('.mp4');
+        const isVideo = this.props.mediaUri && this.props.mediaUri.slice(this.props.mediaUri.length - 4).match('.mp4');
         return (
             <ScrollView ref={ref => this._scrollView = ref} style={styles.container}>
                 <View style={styles.container}>

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 
 import FittedImage from '../common/FittedImage' 
 import SizedMarkdown from '../common/SizedMarkdown'
+import VideoPlayer from 'react-native-video-controls';
 
 const ImageWidth = Math.min(Dimensions.get('window').width - 100, 400)
 class TutorialStep extends Component {
@@ -31,12 +32,29 @@ class TutorialStep extends Component {
     }
 
     render() {
+        const isVideo = this.props.mediaUri.slice(this.props.mediaUri.length - 4).match('.mp4');
         return (
             <ScrollView ref={ref => this._scrollView = ref} style={styles.container}>
                 <View style={styles.container}>
                     <View style={styles.contentContainer} onLayout={this.onLayout}>
                         {
-                            this.props.mediaUri ?
+                            isVideo ? (
+                                <View style={styles.videoContainer}>
+                                    <VideoPlayer
+                                        source={{uri: this.props.mediaUri}}
+                                        style={{
+                                            width: ImageWidth,
+                                            height: (ImageWidth / 4) * 3.4
+                                        }}
+                                        controls={true}
+                                        repeat={true}
+                                        resizeMode='contain'
+                                        disableFullscreen
+                                        disableBack
+                                        disableVolume
+                                        paused={!this.props.isActive}
+                                    />
+                                </View>) : this.props?.mediaUri ? 
                                 <FittedImage 
                                     maxWidth={ImageWidth}
                                     maxHeight={ImageWidth}
@@ -64,14 +82,18 @@ const styles = {
     markdown: {
         flex: 1,
         marginTop: 15
-      },
-      container: {
-          flex: 1
-      },
-      contentContainer: {
-          flex: 1,
-          margin: 25
-      }
+    },
+    container: {
+        flex: 1
+    },
+    contentContainer: {
+        flex: 1,
+        margin: 25
+    },
+    videoContainer: {
+        alignSelf: 'center',
+        width: ImageWidth
+    }
 }
 
 TutorialStep.propTypes = {
@@ -79,6 +101,7 @@ TutorialStep.propTypes = {
     mediaUri: PropTypes.string,
     width: PropTypes.number,
     inMuseumMode: PropTypes.bool,
+    isActive: PropTypes.bool
 }
 
 export default TutorialStep        

--- a/src/components/classifier/TutorialStep.js
+++ b/src/components/classifier/TutorialStep.js
@@ -54,7 +54,8 @@ class TutorialStep extends Component {
                                         disableVolume
                                         paused={!this.props.isActive}
                                     />
-                                </View>) : this.props?.mediaUri ? 
+                                </View>)
+                            : this.props?.mediaUri ? 
                                 <FittedImage 
                                     maxWidth={ImageWidth}
                                     maxHeight={ImageWidth}


### PR DESCRIPTION
- Shows VideoPlayer when tutorial step is an mp4.
- Should match size of tutorial images.
- Should only play when the video tutorial step is active. 
- No functionality with the tutorial images should change.