### PR TITLE
Enable gifs for android in build.gradle file.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,6 +107,7 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+    implementation("com.facebook.fresco:animated-gif:2.5.0")
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {


### PR DESCRIPTION
Adds setting to build.gradle file to enable GIFs on Android per https://reactnative.dev/docs/0.72/image#gif-and-webp-support-on-android