### PR TITLE
Disable edge to edge for android.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,8 +84,8 @@ android {
         applicationId "com.zooniversemobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 95
-        versionName "2.14.0"
+        versionCode 96
+        versionName "2.14.1"
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
           android:resource="@color/background_blue"
           tools:replace="android:resource"/>
       <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" tools:replace="android:value"/>
+      <meta-data
+        android:name="android.window.extensions.disableEdgeToEdge"
+        android:value="true" />
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
     <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">


### PR DESCRIPTION
Disables edge to edge on Android. Edge to edge was introduced in Android SDK 35 but causes issues where it hides the hamburger menu icon preventing users from logging in. Long term fix will be handled in https://github.com/zooniverse/mobile/issues/714