### PR TITLE
Field Guide Fix: check that props has icons before using a potentially null key

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,8 +84,8 @@ android {
         applicationId "com.zooniversemobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 96
-        versionName "2.14.1"
+        versionCode 97
+        versionName "2.14.2"
     }
     signingConfigs {
         debug {

--- a/ios/ZooniverseMobile.xcodeproj/project.pbxproj
+++ b/ios/ZooniverseMobile.xcodeproj/project.pbxproj
@@ -616,7 +616,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZooniverseMobile/ZooniverseMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 888MXXMABP;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
@@ -624,7 +624,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.14.0;
+				MARKETING_VERSION = 2.14.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -646,14 +646,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZooniverseMobile/ZooniverseMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 888MXXMABP;
 				INFOPLIST_FILE = ZooniverseMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.14.0;
+				MARKETING_VERSION = 2.14.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/src/components/classifier/FieldGuideItemRow.js
+++ b/src/components/classifier/FieldGuideItemRow.js
@@ -9,8 +9,8 @@ import { useTranslation } from 'react-i18next';
 import { getCurrentProjectLanguage } from '../../i18n';
 
 const FieldGuideItemRow = (props) => {
-    const { t } = useTranslation();
-    const itemIcon = props.icons[props.item.icon]
+    const { t } = useTranslation();    
+    const itemIcon = props?.icons ? props.icons[props?.item?.icon] : undefined
     return (
       <TouchableOpacity onPress={props.onPress} style={styles.itemRow}>
         {itemIcon !== undefined && itemIcon.src ? (


### PR DESCRIPTION
Fix for Field Guide in case that icons aren't present (we not added / uploaded by team): check props before trying to use a potentially null key.

Closes #738 

# What this change should allow you to do:

Invision Mock-ups: 

# Review Checklist

- [ ] Does it work in Android and iOS?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are tests passing?

# My goals for this PR:

